### PR TITLE
fixing documentation issue

### DIFF
--- a/.ci/Dockerfile.client
+++ b/.ci/Dockerfile.client
@@ -2,6 +2,8 @@ ARG PYTHON_VERSION=3.9
 FROM python:${PYTHON_VERSION}
 
 WORKDIR /code/opensearch-py-ml
+
+RUN apt-get update && apt-get install -y pandoc
 RUN python -m pip install nox
 
 COPY . .

--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -16,6 +16,7 @@ set -e
 echo -e "\033[34;1mINFO:\033[0m URL ${opensearch_url}\033[0m"
 echo -e "\033[34;1mINFO:\033[0m EXTERNAL OS URL ${external_opensearch_url}\033[0m"
 echo -e "\033[34;1mINFO:\033[0m VERSION ${OPENSEARCH_VERSION}\033[0m"
+echo -e "\033[34;1mINFO:\033[0m IS_DOC: ${IS_DOC}\033[0m"
 echo -e "\033[34;1mINFO:\033[0m TEST_SUITE ${TEST_SUITE}\033[0m"
 echo -e "\033[34;1mINFO:\033[0m PYTHON_VERSION ${PYTHON_VERSION}\033[0m"
 echo -e "\033[34;1mINFO:\033[0m PYTHON_CONNECTION_CLASS ${PYTHON_CONNECTION_CLASS}\033[0m"
@@ -31,7 +32,9 @@ docker build \
 
 echo -e "\033[1m>>>>> Run [opensearch-project/opensearch-py-ml container] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
 
-docker run \
+
+if [[ "$IS_DOC" == "false" ]]; then
+  docker run \
   --network=${network_name} \
   --env "STACK_VERSION=${STACK_VERSION}" \
   --env "OPENSEARCH_URL=${opensearch_url}" \
@@ -43,3 +46,20 @@ docker run \
   --rm \
   opensearch-project/opensearch-py-ml \
   nox -s "test-${PYTHON_VERSION}(pandas_version='${PANDAS_VERSION}')"
+else
+  docker run \
+  --network=${network_name} \
+  --cidfile cid.cid \
+  --env "STACK_VERSION=${STACK_VERSION}" \
+  --env "OPENSEARCH_URL=${opensearch_url}" \
+  --env "OPENSEARCH_VERSION=${OPENSEARCH_VERSION}" \
+  --env "TEST_SUITE=${TEST_SUITE}" \
+  --env "PYTHON_CONNECTION_CLASS=${PYTHON_CONNECTION_CLASS}" \
+  --env "TEST_TYPE=server" \
+  --name opensearch-py-ml-doc-runner \
+  opensearch-project/opensearch-py-ml \
+  nox -s docs
+  docker cp opensearch-py-ml-doc-runner:/code/opensearch-py-ml/docs/build/ ./docs/
+
+  docker rm opensearch-py-ml-doc-runner
+fi

--- a/.ci/run-tests
+++ b/.ci/run-tests
@@ -29,14 +29,14 @@ set -euo pipefail
 echo -e "\033[1m>>>>> Start server container >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
 DETACH=true bash $script_path/run-opensearch.sh
 
-if [[ -n "$RUNSCRIPTS" ]]; then
-  for RUNSCRIPT in ${RUNSCRIPTS//,/ } ; do
-    echo -e "\033[1m>>>>> Running run-$RUNSCRIPT.sh >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
-    CONTAINER_NAME=${RUNSCRIPT} \
-      DETACH=true \
-      bash $script_path/run-${RUNSCRIPT}.sh
-  done
-fi
+#if [[ -n "$RUNSCRIPTS" ]]; then
+#  for RUNSCRIPT in ${RUNSCRIPTS//,/ } ; do
+#    echo -e "\033[1m>>>>> Running run-$RUNSCRIPT.sh >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
+#    CONTAINER_NAME=${RUNSCRIPT} \
+#      DETACH=true \
+#      bash $script_path/run-${RUNSCRIPT}.sh
+#  done
+#fi
 
 echo -e "\033[1m>>>>> Repository specific tests >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
 bash $script_path/run-repository.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-docs/*
 example/*
 .git
 .nox

--- a/.github/workflows/build_deploy_doc.yml
+++ b/.github/workflows/build_deploy_doc.yml
@@ -9,17 +9,18 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster: [ "opensearch" ]
+        secured: [ "true" ]
+        entry:
+          - { opensearch_version: 2.3.0 }
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up Python 3
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-      - name: Install dependencies
-        run: python3 -m pip install nox
-      - name: Lint the code
-        run: nox -s docs
+      - name: Integ ${{ matrix.cluster }} secured=${{ matrix.secured }} version=${{matrix.entry.opensearch_version}}
+        run: "./.ci/run-tests ${{ matrix.cluster }} ${{ matrix.secured }} ${{ matrix.entry.opensearch_version }} true"
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -5,6 +5,7 @@ nbval
 sphinx
 sphinx_rtd_theme
 nbsphinx
+pandoc
 
 # traitlets has been having all sorts of release problems lately.
 traitlets<5.1

--- a/noxfile.py
+++ b/noxfile.py
@@ -135,8 +135,6 @@ def docs(session):
     session.install("-r", "docs/requirements-docs.txt")
     session.install(".")
 
-    session.run("python", "-m", "setup_tests")
-
     session.cd("docs")
     session.run("make", "clean", external=True)
     session.run("make", "html", external=True)


### PR DESCRIPTION
Signed-off-by: Dhrubo Saha <dhrubo@amazon.com>

### Description

For document generation, sphinx creates a build folder where all the html files are stored.  For opensearch-py-ml, it's tricky to build docs in github. for opensearch-py-ml, Building docs requires opensearch connection and in github we establish connection using docker. But in docker if we build docs, docs will be generated inside docker. For this reason, we need to take out those documents and then put in the github to deploy the doc.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
