### PR TITLE
Increment jenkins lib version and fix GHA job name

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
       - "*"
 
 jobs:
-  lint:
+  draft-a-release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@1.3.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@1.3.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
The new version of jenkins library fixes the signing bug. See https://github.com/opensearch-project/opensearch-build-libraries/pull/45 for more details.
This change also fixes the GitHub action job name. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
