### PR TITLE
updating docs workflow to 2.5.0 also

### DIFF
--- a/.github/workflows/build_deploy_doc.yml
+++ b/.github/workflows/build_deploy_doc.yml
@@ -15,7 +15,7 @@ jobs:
         cluster: [ "opensearch" ]
         secured: [ "true" ]
         entry:
-          - { opensearch_version: 2.4.0 }
+          - { opensearch_version: 2.5.0 }
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/docs/source/examples/demo_ml_commons_integration.ipynb
+++ b/docs/source/examples/demo_ml_commons_integration.ipynb
@@ -54,7 +54,8 @@
    "outputs": [],
    "source": [
     "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
+    "warnings.filterwarnings('ignore', category=DeprecationWarning)\n",
+    "warnings.filterwarnings(\"ignore\", message=\"Unverified HTTPS request\")\n",
     "from opensearchpy import OpenSearch"
    ],
    "metadata": {

--- a/docs/source/examples/demo_tracing_model_torchscript_onnx.ipynb
+++ b/docs/source/examples/demo_tracing_model_torchscript_onnx.ipynb
@@ -63,6 +63,7 @@
    "source": [
     "import warnings\n",
     "warnings.filterwarnings('ignore', category=DeprecationWarning)\n",
+    "warnings.filterwarnings(\"ignore\", message=\"Unverified HTTPS request\")\n",
     "import opensearch_py_ml as oml\n",
     "from opensearchpy import OpenSearch\n",
     "from opensearch_py_ml.ml_models import SentenceTransformerModel\n",

--- a/docs/source/examples/demo_transformer_model_train_save_upload_to_openSearch.ipynb
+++ b/docs/source/examples/demo_transformer_model_train_save_upload_to_openSearch.ipynb
@@ -83,7 +83,8 @@
    "outputs": [],
    "source": [
     "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
+    "warnings.filterwarnings('ignore', category=DeprecationWarning)\n",
+    "warnings.filterwarnings(\"ignore\", message=\"Unverified HTTPS request\")\n",
     "import opensearch_py_ml as oml\n",
     "from opensearchpy import OpenSearch\n",
     "import generate # generate.py script is release with the \n",


### PR DESCRIPTION
Signed-off-by: Dhrubo Saha <dhrubo@amazon.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[updating docs workflow to 2.5.0 also, limiting filter warning scope]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
