### PR TITLE
Added search model API

### DIFF
--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -198,3 +198,21 @@ class MLCommonClient:
             method="DELETE",
             url=API_URL,
         )
+    
+    def search_model(self, algorithm_name: str = "") -> object:
+        API_URL = f"{ML_BASE_URI}/models/_search"
+
+        if len(algorithm_name) == 0:
+            API_BODY = {"query": {"match_all": {}}}
+        else:
+            API_BODY = {
+                "query": {
+                    "term": {"algorithm": {"value": algorithm_name}}
+                }
+            }
+
+        return self._client.transport.perform_request(
+            method="POST",
+            url=API_URL,
+            body=API_BODY,
+        )

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -165,3 +165,17 @@ def test_integration_model_train_upload_full_cycle():
                 except:  # noqa: E722
                     raised = True
                 assert raised == False, "Raised Exception in deleting model"
+
+                try:
+                    search_model_obj = ml_client.search_model()
+                    assert search_model_obj.get("timed_out") == False
+                except:
+                    raised = True
+                assert raised == False, "Raised Exception in searching all models"
+
+                try:
+                    search_model_obj = ml_client.search_model(algorithm_name="TEXT_EMBEDDING")
+                    assert search_model_obj.get("timed_out") == False
+                except:
+                    raised = True
+                assert raised == False, "Raised Exception in searching all models with given algorithm name"


### PR DESCRIPTION
### Description
Search of models can be done in 2 ways: 1) Search models by default without parameters 2) Search all models with given algorithm name. I tested with and without the parameter. 
Finally, I am not added "size" parameter (models number) but I am tested it. If I will specify "size" approximately less than 800 it works, but if I will specify 1000 then It will throw error: read time out. Let me know if "size" parameter is needed.
 
### Issues Resolved
Link to issue: https://github.com/opensearch-project/opensearch-py-ml/issues/104
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
