### PR TITLE
Added Profile API

### DIFF
--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -6,6 +6,7 @@
 # GitHub history for details.
 
 
+import json
 import time
 from typing import Any, List, Union
 
@@ -327,8 +328,8 @@ class MLCommonClient:
                 url=API_URL,
             )
 
-        if task_ids and len(task_ids) == 1:
-            API_URL = f"{ML_BASE_URI}/profile/tasks/{task_ids[0]}"
+        if task_ids and len(model_ids) == 1:
+            API_URL = f"{ML_BASE_URI}/profile/models/{model_ids[0]}"
             return self._client.transport.perform_request(
                 method="GET",
                 url=API_URL,
@@ -337,12 +338,21 @@ class MLCommonClient:
         API_URL = f"{ML_BASE_URI}/profile"
 
         API_BODY = {
-            "node_ids": node_ids,
-            "model_ids": model_ids,
-            "task_ids": task_ids,
             "return_all_tasks": return_all_tasks,
             "return_all_models": return_all_models,
         }
+
+        if len(node_ids) > 0:
+            API_BODY["node_ids"] = node_ids
+        if len(model_ids) > 0:
+            API_BODY["model_ids"] = model_ids
+        if len(task_ids) > 0:
+            API_BODY["task_ids"] = task_ids
+
+        try:
+            API_BODY = json.dumps(API_BODY)
+        except json.JSONDecodeError:
+            raise Exception("Invalid request body")
 
         return self._client.transport.perform_request(
             method="GET",

--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -294,3 +294,58 @@ class MLCommonClient:
             method="DELETE",
             url=API_URL,
         )
+
+    def get_profiles(
+        self,
+        node_ids: List[str] = [],
+        model_ids: List[str] = [],
+        task_ids: List[str] = [],
+        return_all_tasks: bool = True,
+        return_all_models: bool = True,
+    ) -> object:
+        """
+        This method retrieves the profile of one or more machine learning nodes, models, or tasks from OpenSearch cluster (using ml commons api)
+
+        :param node_ids: A list of node ids to retrieve profiles for (default: [])
+        :type node_ids: List[str]
+        :param model_ids: A list of model ids to retrieve profiles for (default: [])
+        :type model_ids: List[str]
+        :param task_ids: A list of task ids to retrieve profiles for (default: [])
+        :type task_ids: List[str]
+        :param return_all_tasks: a flag to indicate whether all tasks associated with the profiles should be returned (default: True)
+        :type return_all_tasks: bool
+        :param return_all_models: a flag to indicate whether all models associated with the profiles should be returned (default: True)
+        :type return_all_models: bool
+        :return: returns a json object containing the profile information of the specified nodes, models, or tasks from the OpenSearch cluster
+        :rtype: object
+        """
+
+        if model_ids and len(model_ids) == 1:
+            API_URL = f"{ML_BASE_URI}/profile/models/{model_ids[0]}"
+            return self._client.transport.perform_request(
+                method="GET",
+                url=API_URL,
+            )
+
+        if task_ids and len(task_ids) == 1:
+            API_URL = f"{ML_BASE_URI}/profile/tasks/{task_ids[0]}"
+            return self._client.transport.perform_request(
+                method="GET",
+                url=API_URL,
+            )
+
+        API_URL = f"{ML_BASE_URI}/profile"
+
+        API_BODY = {
+            "node_ids": node_ids,
+            "model_ids": model_ids,
+            "task_ids": task_ids,
+            "return_all_tasks": return_all_tasks,
+            "return_all_models": return_all_models,
+        }
+
+        return self._client.transport.perform_request(
+            method="GET",
+            url=API_URL,
+            body=API_BODY,
+        )

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -48,6 +48,19 @@ PRETRAINED_MODEL_FORMAT = "TORCH_SCRIPT"
 UNLOAD_TIMEOUT = 300  # in seconds
 
 
+# traverse the json object to find the key and return the value
+def find_key_value(obj, key_to_find):
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if key == key_to_find:
+                return value
+            elif isinstance(value, dict):
+                result = find_key_value(value, key_to_find)
+                if result is not None:
+                    return result
+    return None
+
+
 def clean_test_folder(TEST_FOLDER):
     if os.path.exists(TEST_FOLDER):
         for files in os.listdir(TEST_FOLDER):
@@ -168,6 +181,18 @@ def test_integration_model_train_upload_full_cycle():
             except:  # noqa: E722
                 raised = True
             assert raised == False, "Raised Exception in getting model info"
+
+            try:
+                get_profile_obj = ml_client.get_profiles()
+                get_profile_models = ml_client.get_profiles(model_ids=[model_id])
+                get_profile_tasks = ml_client.get_profiles(task_ids=[task_id])
+                assert find_key_value(get_profile_obj, "model_id") == model_id
+                assert find_key_value(get_profile_obj, "task_id") == task_id
+                assert find_key_value(get_profile_models, "model_id") == model_id
+                assert find_key_value(get_profile_tasks, "task_id") == task_id
+            except:  # noqa: E722
+                raised = True
+            assert raised == False, "Raised Exception in getting profile"
 
             if task_id:
                 raised = False


### PR DESCRIPTION
### Description
These three methods all retrieve different types of profiles from an OpenSearch cluster using the ML Commons API. Here's a brief description of each method:

**def get_profile(self, node_ids: List[str] = [], return_all_tasks: bool = True, return_all_models: bool = True) -> object:**

This method retrieves a profile from an OpenSearch cluster for one or more specified node IDs.

**def get_profile_models(self, model_ids: List[str] = []) -> object:**

This method retrieves a profile from an OpenSearch cluster for one or more specified machine learning models.

**def get_profile_tasks(self, task_ids: List[str] = []) -> object:**

This method retrieves a profile from an OpenSearch cluster for one or more specified machine learning tasks.

All three methods are similar in structure and use the same API endpoint to retrieve different types of profiles based on the parameters passed to them.
 
### Issues Resolved
Link to issue: [#104 ](https://github.com/opensearch-project/opensearch-py-ml/issues/104)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
