### PR TITLE
Tests for mcorr libraries

### DIFF
--- a/opensearch_py_ml/ml_models/metrics_correlation/event_detection.py
+++ b/opensearch_py_ml/ml_models/metrics_correlation/event_detection.py
@@ -107,10 +107,12 @@ def merge_events(
             currend = send[i]
             currevent = sevents[i, :]
         elif s > currend:  # start of new event; record previous one
-            merged.append({
-                "range": torch.stack([currstart, currend]),
-                "event": currevent,
-            })
+            merged.append(
+                {
+                    "range": torch.stack([currstart, currend]),
+                    "event": currevent,
+                }
+            )
             currstart = s
             currend = send[i]
             currevent = sevents[i, :]
@@ -120,10 +122,12 @@ def merge_events(
 
     # record final event
     if currstart > 0:
-        merged.append({
-            "range": torch.stack([currstart, currend]),
-            "event": currevent,
-        })
+        merged.append(
+            {
+                "range": torch.stack([currstart, currend]),
+                "event": currevent,
+            }
+        )
     return merged
 
 

--- a/opensearch_py_ml/ml_models/metrics_correlation/mcorr.py
+++ b/opensearch_py_ml/ml_models/metrics_correlation/mcorr.py
@@ -4,7 +4,7 @@
 # compatible open source license.
 # Any modifications Copyright OpenSearch Contributors. See
 # GitHub history for details.
-from typing import Dict
+from typing import Dict, List
 
 import torch
 
@@ -27,7 +27,7 @@ class MCorr(torch.nn.Module):
 
     def forward(
         self, metrics: torch.Tensor, max_events: int = 3, wavelet_approx: bool = True
-    ) -> Dict[int, Dict[str, torch.Tensor]]:
+    ) -> List[Dict[str, torch.Tensor]]:
         """
         Main entry point of the Metrics Correlation algorithm.
 
@@ -38,7 +38,7 @@ class MCorr(torch.nn.Module):
         :param wavelet_approx
         :type wavelet_approx: int
         :return:
-        :rtype: Dict[int, Dict[str, torch.Tensor]]
+        :rtype: List[int, Dict[str, torch.Tensor]]
         """
 
         #

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,8 @@ pytest>=7.1.2
 pytest-mock
 pytest-cov
 nbval
+pywavelets
+scikit-learn
 
 #
 # Docs

--- a/tests/ml_models/test_mcorr_dip_pytest.py
+++ b/tests/ml_models/test_mcorr_dip_pytest.py
@@ -22,6 +22,13 @@ import opensearch_py_ml.ml_models.metrics_correlation.dip as dip
 
 
 def test_dip_statistic():
+    '''
+    test correctness by computing the dip statistic on 
+    various input sequences. comparisons are made to the
+    equivalent output from the R package 'diptest', the 
+    canonical implementation of this method.
+    '''
+
     T = 128
 
     # uniform eCDF
@@ -54,6 +61,11 @@ def test_dip_statistic():
 
 
 def test_dip_pval():
+    '''
+    as above, reference values (this time for p-values)
+    are obtained from R package 'diptest'
+    '''
+
     # bimodal : p near zero
     T = 256
     xa = torch.arange(T + 1) / (T / 10)
@@ -148,8 +160,8 @@ def test_torchscript_output():
 
     tsD, tsP = loaded_model.forward(sig)
 
-    assert np.allclose(ptD, tsD)
-    assert np.allclose(ptP, tsP)
+    assert np.allclose(ptD, tsD, rtol=0, atol=0)
+    assert np.allclose(ptP, tsP, rtol=0, atol=0)
 
     os.remove("diptest.pt")
 

--- a/tests/ml_models/test_mcorr_dip_pytest.py
+++ b/tests/ml_models/test_mcorr_dip_pytest.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Any modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""
+Tests of correctness and compilation for the dip test module
+of metrics correlation.
+
+"True" values here can be verified by comparison to established
+implementations such as the R package 'diptest'.
+"""
+
+import os
+
+import numpy as np
+import torch
+
+import opensearch_py_ml.ml_models.metrics_correlation.dip as dip
+
+
+def test_dip_statistic():
+    T = 128
+
+    # uniform eCDF
+    unifseq = torch.arange(T)
+    assert torch.abs(dip.dip(unifseq) - 0.003906) <= 1e-6
+
+    # uniform with large spike
+    unifspike = torch.arange(T)
+    unifspike[:50] = 20
+
+    assert torch.abs(dip.dip(unifspike) - 0.085426) <= 1e-6
+
+    # unimodal Gaussian
+    xs = torch.arange(-T // 2, T // 2 + 1)
+    x = torch.exp(-(xs**2) / 20)
+
+    assert torch.abs(dip.dip(x) - 0.010517) <= 1e-6
+
+    # max of 0.25 is (approx) achieved for (approx) bimodal data
+    apx_bimodal = torch.cat(
+        ((torch.normal(1.0, 0.001, [T // 2])), torch.normal(2.0, 0.001, [T // 2]))
+    )
+
+    assert dip.dip(apx_bimodal) >= 0.2475 and dip.dip(apx_bimodal) <= 0.25
+
+    # overlapping bimodal (mixture of Gaussians)
+    x_mog = torch.exp(-((xs - 5.0) ** 2) / 5) + torch.exp(-((xs + 5.0) ** 2) / 10)
+
+    assert torch.abs(dip.dip(x_mog) - 0.013016) <= 1e-6
+
+
+def test_dip_pval():
+    # bimodal : p near zero
+    T = 256
+    xa = torch.arange(T + 1) / (T / 10)
+    xb = torch.arange(T + 1) / (T / 30)
+    x = torch.cat((xa - 10, xb + 15))
+    _, p = dip.diptest(x)
+
+    assert p > 0 and p < 0.01
+
+    # unimodal : p near one
+    x = torch.cat((xa + 15, xb + 5))
+    _, p = dip.diptest(x)
+
+    assert p < 1.0 and p > 0.98
+
+    # in-between cases to check interpolation
+    x = torch.cat((xa - 7, xb + 5))
+    _, p = dip.diptest(x)
+
+    assert np.abs(p - 0.57) < 0.01
+
+    T = 512
+    xa = torch.arange(T + 1) / (T / 10)
+    xb = torch.arange(T + 1) / (T / 30)
+    x = torch.cat((xa - 7, xb + 5))
+    _, p = dip.diptest(x)
+
+    assert np.abs(p - 0.09) < 0.01
+
+    T = 1024
+    xa = torch.arange(T + 1) / (T / 10)
+    xb = torch.arange(T + 1) / (T / 30)
+    x = torch.cat((xa - 6, xb + 5))
+    _, p = dip.diptest(x)
+
+    assert np.abs(p - 0.54) < 0.01
+
+
+def test_interp():
+    xs = torch.linspace(0, 1, 12) * 2 * torch.pi
+    ys = torch.sin(xs)
+
+    # should linearly interpolate within region
+    for _ in range(5):
+        newx = torch.rand([1])
+        newy = dip.interp(newx, xs, ys)
+        newy_np = np.interp(newx.numpy(), xs.numpy(), ys.numpy())
+
+        assert np.abs(newy - newy_np) <= 1e-6
+
+    # should return endpoints if outside (i.e. constant interp)
+    newy_low = dip.interp(torch.tensor([-1.0]), xs, ys)
+    newy_hi = dip.interp(torch.tensor([10.0]), xs, ys)
+
+    assert newy_low == ys[0].item()
+    assert newy_hi == ys[-1].item()
+
+
+def test_torchscript_scripting():
+    # test scripting and save / load of scripted model
+    model = DipTest()
+
+    try:
+        jit_processing = torch.jit.script(model)
+    except Exception as exec:
+        assert False, f"Failed to script model with exception {exec}"
+
+    try:
+        torch.jit.save(jit_processing, "diptest.pt")
+    except Exception as exec:
+        assert False, f"Failed to save model with exception {exec}"
+
+    try:
+        _ = torch.jit.load("diptest.pt")
+    except Exception as exec:
+        assert False, f"Failed to load scripted model with exception {exec}"
+
+    os.remove("diptest.pt")
+
+
+def test_torchscript_output():
+    # check scripted model output is same as pytorch
+    sig = torch.normal(mean=0, std=1, size=[128])
+
+    model = DipTest()
+    ptD, ptP = model(sig)
+
+    model = DipTest()
+    jit_processing = torch.jit.script(model)
+    torch.jit.save(jit_processing, "diptest.pt")
+    loaded_model = torch.jit.load("diptest.pt")
+
+    tsD, tsP = loaded_model.forward(sig)
+
+    assert np.allclose(ptD, tsD)
+    assert np.allclose(ptP, tsP)
+
+    os.remove("diptest.pt")
+
+
+class DipTest(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def forward(self, sig: torch.Tensor):
+        return dip.diptest(sig)

--- a/tests/ml_models/test_mcorr_dip_pytest.py
+++ b/tests/ml_models/test_mcorr_dip_pytest.py
@@ -22,12 +22,12 @@ import opensearch_py_ml.ml_models.metrics_correlation.dip as dip
 
 
 def test_dip_statistic():
-    '''
-    test correctness by computing the dip statistic on 
+    """
+    test correctness by computing the dip statistic on
     various input sequences. comparisons are made to the
-    equivalent output from the R package 'diptest', the 
+    equivalent output from the R package 'diptest', the
     canonical implementation of this method.
-    '''
+    """
 
     T = 128
 
@@ -61,10 +61,10 @@ def test_dip_statistic():
 
 
 def test_dip_pval():
-    '''
+    """
     as above, reference values (this time for p-values)
     are obtained from R package 'diptest'
-    '''
+    """
 
     # bimodal : p near zero
     T = 256

--- a/tests/ml_models/test_mcorr_nmf_pytest.py
+++ b/tests/ml_models/test_mcorr_nmf_pytest.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Any modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""
+Tests of correctness and compilation for the NMF test module
+of metrics correlation.
+"""
+
+import os
+
+import numpy as np
+import torch
+from sklearn.decomposition import NMF as skNMF
+from sklearn.decomposition._nmf import _initialize_nmf
+
+import opensearch_py_ml.ml_models.metrics_correlation.nmf as nmf
+
+
+def test_nmf_init():
+    # check correctness of nndsvd-a initialization
+    T = 32
+    M = 5
+    n_component = 3
+
+    nmf_model = nmf.NMF()
+    for _ in range(5):
+        X = torch.normal(mean=0, std=1, size=[M, T]) ** 2
+
+        Wsk, Hsk = _initialize_nmf(X.numpy(), n_component, init="nndsvda")
+        Wpt, Hpt = nmf_model.initialize(X, n_component)
+
+        W_rel_err = np.linalg.norm(Wpt.numpy() - Wsk) / np.linalg.norm(Wsk)
+        H_rel_err = np.linalg.norm(Hpt.numpy() - Hsk) / np.linalg.norm(Hsk)
+
+        assert W_rel_err <= 1e-4
+        assert H_rel_err <= 1e-4
+
+
+def test_nmf_forward():
+    # compare multiplicative-update iterations
+    T = 32
+    M = 5
+    iters = [5, 20, 50]
+
+    n_component = 3
+    nmf_model = nmf.NMF()
+    sk_model = skNMF(n_components=n_component, solver="mu", init="nndsvda", max_iter=10)
+
+    for _ in range(5):
+        X = torch.normal(mean=0, std=1, size=[M, T]) ** 2
+
+        for iter in iters:
+            sk_model = skNMF(
+                n_components=n_component, solver="mu", init="nndsvda", max_iter=iter
+            )
+            Wsk = sk_model.fit_transform(X.numpy())
+            Hsk = sk_model.components_
+
+            Wpt, Hpt = nmf_model(X, k=3, max_iter=iter, tol=1e-8)
+
+            W_rel_err = np.linalg.norm(Wpt.numpy() - Wsk) / np.linalg.norm(Wsk)
+            H_rel_err = np.linalg.norm(Hpt.numpy() - Hsk) / np.linalg.norm(Hsk)
+
+            assert W_rel_err <= 0.01
+            assert H_rel_err <= 0.01
+
+
+def test_torchscript_scripting():
+    # test scripting and save / load of scripted model
+    model = nmf.NMF()
+
+    try:
+        jit_processing = torch.jit.script(model)
+    except Exception as exec:
+        assert False, f"Failed to script model with exception {exec}"
+
+    try:
+        torch.jit.save(jit_processing, "nmftest.pt")
+    except Exception as exec:
+        assert False, f"Failed to save model with exception {exec}"
+
+    try:
+        _ = torch.jit.load("nmftest.pt")
+    except Exception as exec:
+        assert False, f"Failed to load scripted model with exception {exec}"
+
+    os.remove("nmftest.pt")
+
+
+def test_torchscript_output():
+    # check scripted model output is same as pytorch
+    X = torch.normal(mean=0, std=1, size=[5, 32]) ** 2
+
+    model = nmf.NMF()
+    ptW, ptH = model(X, 3, 200, 1e-6)
+
+    model = nmf.NMF()
+    jit_processing = torch.jit.script(model)
+    torch.jit.save(jit_processing, "nmftest.pt")
+    loaded_model = torch.jit.load("nmftest.pt")
+
+    tsW, tsH = loaded_model.forward(X, 3, 200, 1e-6)
+
+    assert torch.allclose(ptW, tsW)
+    assert torch.allclose(ptH, tsH)
+
+    os.remove("nmftest.pt")

--- a/tests/ml_models/test_mcorr_nmf_pytest.py
+++ b/tests/ml_models/test_mcorr_nmf_pytest.py
@@ -36,6 +36,9 @@ def test_nmf_init():
         W_rel_err = np.linalg.norm(Wpt.numpy() - Wsk) / np.linalg.norm(Wsk)
         H_rel_err = np.linalg.norm(Hpt.numpy() - Hsk) / np.linalg.norm(Hsk)
 
+        # check relative errors for matrix-level similarity
+        # and to avoid failing due to ignorable elementwise
+        # numerical differences
         assert W_rel_err <= 1e-4
         assert H_rel_err <= 1e-4
 
@@ -65,6 +68,9 @@ def test_nmf_forward():
             W_rel_err = np.linalg.norm(Wpt.numpy() - Wsk) / np.linalg.norm(Wsk)
             H_rel_err = np.linalg.norm(Hpt.numpy() - Hsk) / np.linalg.norm(Hsk)
 
+            # check relative errors for matrix-level similarity
+            # and to avoid failing due to ignorable elementwise
+            # numerical differences
             assert W_rel_err <= 0.01
             assert H_rel_err <= 0.01
 
@@ -105,7 +111,7 @@ def test_torchscript_output():
 
     tsW, tsH = loaded_model.forward(X, 3, 200, 1e-6)
 
-    assert torch.allclose(ptW, tsW)
-    assert torch.allclose(ptH, tsH)
+    torch.testing.assert_close(ptW, tsW, rtol=0, atol=0)
+    torch.testing.assert_close(ptH, tsH, rtol=0, atol=0)
 
     os.remove("nmftest.pt")

--- a/tests/ml_models/test_mcorr_wavelet_pytest.py
+++ b/tests/ml_models/test_mcorr_wavelet_pytest.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Any modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""
+Tests of correctness and compilation for the wavelet module
+of metrics correlation.
+"""
+
+import os
+
+import numpy as np
+import pywt
+import torch
+
+import opensearch_py_ml.ml_models.metrics_correlation.wavelet_piecewise_const as wavpc
+import opensearch_py_ml.ml_models.metrics_correlation.wavelet_tools as wavtools
+
+
+def test_haar_approx():
+    # no truncation -> should return original signal
+    T = 32
+    for _ in range(5):
+        sig = torch.normal(mean=0, std=1, size=[T])
+        assert torch.allclose(wavtools.haar_approx(sig, T), sig, atol=1e-6)
+
+
+def test_haar_truncate():
+    # test truncation against pywavelet library
+    trunc = 10
+    for _ in range(5):
+        sig = torch.normal(mean=0, std=1, size=[32])
+        signp = sig.numpy()
+
+        dec = pywt.wavedec(signp, "haar")
+        arr, slices = pywt.coeffs_to_array(dec)
+        not_top = np.argsort(arr**2)[:-trunc]
+        arr[not_top] = 0
+        rec = pywt.waverec(
+            pywt.array_to_coeffs(arr, slices, output_format="wavedec"), "haar"
+        )
+
+        ptapx = wavtools.haar_approx(sig, truncate=trunc)
+
+        assert torch.allclose(ptapx, torch.FloatTensor(rec), atol=1e-6)
+
+
+def test_haar_padding():
+    # test zero padding
+    T = 17
+    for _ in range(5):
+        sig = torch.normal(mean=0, std=1, size=[T])
+
+        dec = pywt.wavedec(sig, "haar", mode="zero")
+        rec = pywt.waverec(dec, "haar", mode="zero")[:T]
+
+        ptapx = wavtools.haar_approx(sig, truncate=T)
+
+        assert torch.allclose(ptapx, torch.FloatTensor(rec), atol=1e-6)
+
+
+def test_lavielle_criterion():
+    # no curvature (linear cost curve) -> select k=1
+    costs = torch.arange(5) * -1 + 10
+    k, _ = wavpc.lavielle_criterion(costs)
+    assert k == 1
+
+    # elbow at 3 -> select k=3
+    costs = 1 / torch.arange(2, 12) ** 4
+    k, _ = wavpc.lavielle_criterion(costs)
+    assert k == 3
+
+
+def test_blockwise_DP_seg():
+    T = 32
+    max_lvls = 5
+    for _ in range(5):
+        sig = torch.normal(mean=0, std=1, size=[T])
+        segs, costs = wavpc.block_wise_dp_segment(sig, max_lvls=max_lvls)
+
+        for m in range(max_lvls):
+            # at each level i, segs should be len i+1 w/ increasing indices
+            assert len(segs[m + 1]) == m + 2
+            assert np.all(np.diff(segs[m + 1]) > 0)
+
+            # at each level i, costs should not decrease across rows
+            assert np.all(np.diff(costs[m, :]) >= 0)
+
+        # costs should decrease down columns
+        assert np.all(np.diff(costs[:, -1]) <= 0)
+
+
+def test_seg_to_approx():
+    T = 32
+    for _ in range(5):
+        sig = torch.normal(mean=0, std=1, size=[T])
+
+        # generate segments
+        nseg = np.random.choice(np.arange(1, 5))
+        seg = (
+            [0]
+            + list(np.sort(np.random.choice(np.arange(1, T), nseg, replace=False)))
+            + [T]
+        )
+
+        apx = wavpc.block_wise_seg_to_approx(sig, seg)
+
+        # approximation should have # unique vals = # segments
+        assert len(torch.unique(apx)) == len(seg) - 1
+
+        for i in range(len(seg) - 1):
+            seg_start = seg[i]
+            seg_end = seg[i + 1] - 1
+
+            # approximation should be constant inside segments
+            assert len(torch.unique(apx[seg_start : (seg_end + 1)])) == 1
+
+            # segments are left-closed, right open
+            assert apx[seg_start] == apx[seg_end]
+            if i < (len(seg) - 2):
+                assert apx[seg_start] != apx[seg_end + 1]
+
+
+def test_transform_piecewise_constant():
+    T = 32
+
+    # transform of all-zero input is all-zeros
+    sig = torch.zeros(T)
+    for bw in [0.1, 1.0, 10.0]:
+        scores = wavpc.transform_piecewise_const(sig, bw)
+        assert torch.allclose(sig[:-1], scores)
+
+    # scores should always be non-negative
+    sig[: T // 2] -= 10.0
+    for _ in range(5):
+        ix = np.random.choice(T)
+        sig[ix:] += torch.normal(0, 1, [1]).item() * 5
+        scores = wavpc.transform_piecewise_const(sig, 1.0)
+        assert torch.all(scores >= 0)
+
+    # blurring should reduce sharp changes
+    # see https://en.wikipedia.org/wiki/Young%27s_convolution_inequality
+    ixs = np.random.choice(T, 3, replace=False)
+    sig[ixs] += 20
+
+    scores = wavpc.transform_piecewise_const(sig, 1.0)
+    assert torch.max(scores) <= torch.max(torch.diff(sig))
+
+
+def test_torchscript_scripting():
+    # test scripting and save / load of scripted model
+    model = WavTest()
+
+    try:
+        jit_processing = torch.jit.script(model)
+    except Exception as exec:
+        assert False, f"Failed to script model with exception {exec}"
+
+    try:
+        torch.jit.save(jit_processing, "wavtest.pt")
+    except Exception as exec:
+        assert False, f"Failed to save model with exception {exec}"
+
+    try:
+        _ = torch.jit.load("wavtest.pt")
+    except Exception as exec:
+        assert False, f"Failed to load scripted model with exception {exec}"
+
+    os.remove("wavtest.pt")
+
+
+def test_torchscript_output():
+    # check scripted model output is same as pytorch
+    sig = torch.normal(mean=0, std=1, size=[1, 32])
+
+    model = WavTest()
+    ptscores = model(sig, 5, 2.0)
+
+    model = WavTest()
+    jit_processing = torch.jit.script(model)
+    torch.jit.save(jit_processing, "wavtest.pt")
+    loaded_model = torch.jit.load("wavtest.pt")
+
+    tsscores = loaded_model.forward(sig, 5, 2.0)
+
+    assert torch.allclose(ptscores, tsscores, atol=1e-6)
+
+    os.remove("wavtest.pt")
+
+
+class WavTest(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def forward(self, sig: torch.Tensor, max_dp_levels: int, bandwidth: float):
+        apx = wavpc.wavelet_piecewise_const(sig, 0, max_dp_levels, True)
+        scores = wavpc.transform_piecewise_const(apx, bandwidth)
+        return scores

--- a/tests/ml_models/test_mcorr_wavelet_pytest.py
+++ b/tests/ml_models/test_mcorr_wavelet_pytest.py
@@ -25,7 +25,7 @@ def test_haar_approx():
     T = 32
     for _ in range(5):
         sig = torch.normal(mean=0, std=1, size=[T])
-        assert torch.allclose(wavtools.haar_approx(sig, T), sig, atol=1e-6)
+        torch.testing.assert_close(wavtools.haar_approx(sig, T), sig)
 
 
 def test_haar_truncate():
@@ -45,7 +45,7 @@ def test_haar_truncate():
 
         ptapx = wavtools.haar_approx(sig, truncate=trunc)
 
-        assert torch.allclose(ptapx, torch.FloatTensor(rec), atol=1e-6)
+        torch.testing.assert_close(ptapx, torch.FloatTensor(rec))
 
 
 def test_haar_padding():
@@ -59,7 +59,7 @@ def test_haar_padding():
 
         ptapx = wavtools.haar_approx(sig, truncate=T)
 
-        assert torch.allclose(ptapx, torch.FloatTensor(rec), atol=1e-6)
+        torch.testing.assert_close(ptapx, torch.FloatTensor(rec))
 
 
 def test_lavielle_criterion():
@@ -131,7 +131,7 @@ def test_transform_piecewise_constant():
     sig = torch.zeros(T)
     for bw in [0.1, 1.0, 10.0]:
         scores = wavpc.transform_piecewise_const(sig, bw)
-        assert torch.allclose(sig[:-1], scores)
+        torch.testing.assert_close(sig[:-1], scores)
 
     # scores should always be non-negative
     sig[: T // 2] -= 10.0
@@ -186,7 +186,7 @@ def test_torchscript_output():
 
     tsscores = loaded_model.forward(sig, 5, 2.0)
 
-    assert torch.allclose(ptscores, tsscores, atol=1e-6)
+    torch.testing.assert_close(ptscores, tsscores, rtol=0, atol=0)
 
     os.remove("wavtest.pt")
 


### PR DESCRIPTION
### Description
This PR adds tests for the following tools used by metrics correlation:
- Haar discrete wavelet transformation:`wavelet_tools.py`
- Piecewise constant approximation and activity scoring: `wavelet_piecewise_const.py`
- Dip test for unimodality: `dip.py`
- Nonnegative matrix factorization with NNDSVD-A initialization: `nmf.py`
 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
