### PR TITLE
Adding new OpenSearch versions(#117)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,10 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cluster: ["opensearch"]
-        secured: ["true"]
-        entry:
-          - { opensearch_version: 2.6.0 }
+      opensearch_version: [ '2.4.0' , '2.5.0' , '2.6.0']
+      secured: [ "true", "false" ]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description
Currently opensearch-py-ml has integration test for only [opensearch version 2.5.0]
(https://github.com/opensearch-project/opensearch-py-ml/blob/main/.github/workflows/integration.yml#L15)
Added integration for previous version (2.4.0) and the most updated version (2.6.0)
 
### Issues Resolved
Adding new OpenSearch versions 
 
### Check List
List any issues this PR will resolve, e.g. Closes [...].


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
