### PR TITLE
[CCI][FEATURE] Add test coverage statistics to Codecov 

### DIFF
--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -43,9 +43,11 @@ if [[ "$IS_DOC" == "false" ]]; then
   --env "PYTHON_CONNECTION_CLASS=${PYTHON_CONNECTION_CLASS}" \
   --env "TEST_TYPE=server" \
   --name opensearch-py-ml-test-runner \
-  --rm \
   opensearch-project/opensearch-py-ml \
   nox -s "test-${PYTHON_VERSION}(pandas_version='${PANDAS_VERSION}')"
+  docker cp opensearch-py-ml-test-runner:/code/opensearch-py-ml/junit/ ./junit/
+
+  docker rm opensearch-py-ml-test-runner
 else
   docker run \
   --network=${network_name} \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,3 +19,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Integ ${{ matrix.cluster }} secured=${{ matrix.secured }} version=${{matrix.entry.opensearch_version}}
         run: "./.ci/run-tests ${{ matrix.cluster }} ${{ matrix.secured }} ${{ matrix.entry.opensearch_version }}"
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./junit/opensearch-py-codecov.xml

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,4 +23,4 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./junit/opensearch-py-codecov.xml
+          files: ./junit/opensearch-py-ml-codecov.xml

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ venv.bak/
 # Coverage
 .coverage
 .coverage.*
+*-junit.xml
+*-codecov.xml
 
 #model file
 all-MiniLM-L6-v2_torchscript_sentence-transformer.zip

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,9 +27,12 @@ from pathlib import Path
 
 import nox
 
+from os.path import abspath, dirname, exists, join, pardir
+
 BASE_DIR = Path(__file__).parent
 # SOURCE_FILES = ("setup.py", "noxfile.py", "eland/", "docs/", "utils/", "tests/", "bin/")
-SOURCE_FILES = ("setup.py", "noxfile.py", "opensearch_py_ml/", "utils/", "tests/")
+SOURCE_FILES = ("setup.py", "noxfile.py",
+                "opensearch_py_ml/", "utils/", "tests/")
 
 # Whenever type-hints are completed on a file it should
 # be added here so that this file will continue to be checked
@@ -115,6 +118,14 @@ def test(session, pandas_version: str):
     session.run("python", "-m", "pip", "install", f"pandas~={pandas_version}")
     session.run("python", "-m", "setup_tests")
 
+    junit_xml = join(
+        abspath(dirname(__file__)), "junit", "opensearch-py-junit.xml"
+    )
+    codecov_xml = join(
+        abspath(dirname(__file__)
+                ), "junit", "opensearch-py-codecov.xml"
+    )
+
     pytest_args = (
         "python",
         "-m",
@@ -124,6 +135,8 @@ def test(session, pandas_version: str):
         "--cov-config=setup.cfg",
         "--doctest-modules",
         "--nbval",
+        "--junitxml=%s" % junit_xml,
+        "--cov-report=xml:%s" % codecov_xml,
     )
 
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,16 +23,13 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from os.path import abspath, dirname, join
 from pathlib import Path
 
 import nox
 
-from os.path import abspath, dirname, exists, join, pardir
-
 BASE_DIR = Path(__file__).parent
-# SOURCE_FILES = ("setup.py", "noxfile.py", "eland/", "docs/", "utils/", "tests/", "bin/")
-SOURCE_FILES = ("setup.py", "noxfile.py",
-                "opensearch_py_ml/", "utils/", "tests/")
+SOURCE_FILES = ("setup.py", "noxfile.py", "opensearch_py_ml/", "utils/", "tests/")
 
 # Whenever type-hints are completed on a file it should
 # be added here so that this file will continue to be checked
@@ -118,12 +115,9 @@ def test(session, pandas_version: str):
     session.run("python", "-m", "pip", "install", f"pandas~={pandas_version}")
     session.run("python", "-m", "setup_tests")
 
-    junit_xml = join(
-        abspath(dirname(__file__)), "junit", "opensearch-py-junit.xml"
-    )
+    junit_xml = join(abspath(dirname(__file__)), "junit", "opensearch-py-ml-junit.xml")
     codecov_xml = join(
-        abspath(dirname(__file__)
-                ), "junit", "opensearch-py-codecov.xml"
+        abspath(dirname(__file__)), "junit", "opensearch-py-ml-codecov.xml"
     )
 
     pytest_args = (
@@ -135,8 +129,8 @@ def test(session, pandas_version: str):
         "--cov-config=setup.cfg",
         "--doctest-modules",
         "--nbval",
-        "--junitxml=%s" % junit_xml,
-        "--cov-report=xml:%s" % codecov_xml,
+        f"--junitxml={junit_xml}",
+        f"--cov-report=xml:{codecov_xml}",
     )
 
     session.run(


### PR DESCRIPTION
### Description
Fixed a bug where test coverage was incorrectly displayed in the [codecov](https://app.codecov.io/gh/opensearch-project/opensearch-py-ml) web interface
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/55043014/230586925-687910a3-966f-4051-a1e3-1b37effd7cd4.png">

 
### Issues Resolved
#118 
 
### Check List
- [+] New functionality includes testing.
  - [+] All tests pass
- [+] New functionality has been documented.
  - [+] New functionality has javadoc added
- [+] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
