### PR TITLE
Update jenkins file to use updated docker image

### DIFF
--- a/jenkins/ml-models.JenkinsFile
+++ b/jenkins/ml-models.JenkinsFile
@@ -8,7 +8,7 @@ pipeline {
     {
         docker {
             label 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host'
-            image 'opensearchstaging/ci-runner:release-centos7-clients-v2'
+            image 'opensearchstaging/ci-runner:release-centos7-clients-v4'
             alwaysPull true
         }
     }


### PR DESCRIPTION
### Description
We recently upgraded the python version in the build repo. Due to this any code using build repo code fails if right python version is not used. Signing artifacts uses the build repo code hence updating the image to most recent one.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3712
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
