### PR TITLE
Make `make_model_config_json` function more concise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fix ModelUploader bug & Update model tracing demo notebook by @thanawan-atc in ([#185](https://github.com/opensearch-project/opensearch-py-ml/pull/185))
 - Fix make_model_config_json function by @thanawan-atc in ([#188](https://github.com/opensearch-project/opensearch-py-ml/pull/188))
+- Make make_model_config_json function more concise by @thanawan-atc in ([#191](https://github.com/opensearch-project/opensearch-py-ml/pull/191))
 
 ## [1.0.0]    
 

--- a/opensearch_py_ml/ml_models/sentencetransformermodel.py
+++ b/opensearch_py_ml/ml_models/sentencetransformermodel.py
@@ -1080,7 +1080,7 @@ class SentenceTransformerModel:
                 normalize_result = True
             else:
                 normalize_result = False
-                
+
         model_config_content = {
             "name": model_name,
             "version": version_number,
@@ -1091,7 +1091,7 @@ class SentenceTransformerModel:
                 "embedding_dimension": embedding_dimension,
                 "framework_type": "sentence_transformers",
                 "pooling_mode": pooling_mode,
-                "normalize_result": normalize_result
+                "normalize_result": normalize_result,
                 "all_config": json.dumps(all_config),
             },
         }

--- a/opensearch_py_ml/ml_models/sentencetransformermodel.py
+++ b/opensearch_py_ml/ml_models/sentencetransformermodel.py
@@ -1024,25 +1024,39 @@ class SentenceTransformerModel:
 
         # if user input model_type/embedding_dimension/pooling_mode, it will skip this step.
         model = SentenceTransformer(self.model_id)
-        if model_type is None or embedding_dimension is None or pooling_mode is None or normalize_result is None:
+        if (
+            model_type is None
+            or embedding_dimension is None
+            or pooling_mode is None
+            or normalize_result is None
+        ):
             try:
-                if model_type is None and len(model._modules) >= 1 and isinstance(
-                    model._modules["0"], Transformer
+                if (
+                    model_type is None
+                    and len(model._modules) >= 1
+                    and isinstance(model._modules["0"], Transformer)
                 ):
                     model_type = model._modules["0"].auto_model.__class__.__name__
                     model_type = model_type.lower().rstrip("model")
                 if embedding_dimension is None:
                     embedding_dimension = model.get_sentence_embedding_dimension()
-                if pooling is None and len(model._modules) >= 2 and isinstance(model._modules["1"], Pooling):
+                if (
+                    pooling_mode is None
+                    and len(model._modules) >= 2
+                    and isinstance(model._modules["1"], Pooling)
+                ):
                     pooling_mode = model._modules["1"].get_pooling_mode_str().upper()
                 if normalize_result is None:
-                    if len(model._modules) >= 3 and isinstance(model._modules["2"], Normalize):
+                    if len(model._modules) >= 3 and isinstance(
+                        model._modules["2"], Normalize
+                    ):
                         normalize_result = True
                     else:
                         normalize_result = False
             except Exception as e:
-                raise Exception(f"Raised exception while getting model data from pre-trained hugging-face model object: {e}")
-
+                raise Exception(
+                    f"Raised exception while getting model data from pre-trained hugging-face model object: {e}"
+                )
 
         if all_config is None:
             if not os.path.exists(config_json_file_path):

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -303,6 +303,7 @@ def test_integration_model_train_register_full_cycle():
         zip_file_name=MODEL_FILE_ZIP_NAME,
         num_epochs=1,
         overwrite=True,
+        verbose=True,
     )
     # second generating the config file to create metadoc of the model in opensearch.
     test_model.make_model_config_json()

--- a/tests/ml_models/test_sentencetransformermodel_pytest.py
+++ b/tests/ml_models/test_sentencetransformermodel_pytest.py
@@ -8,7 +8,6 @@
 import json
 import os
 import shutil
-from zipfile import ZipFile
 
 import pytest
 
@@ -107,17 +106,6 @@ def test_missing_files():
 
     with pytest.raises(FileNotFoundError):
         test_model.read_queries(read_path="1234")
-        
-    with pytest.raises(Exception) as exc_info:
-        empty_test_path = os.path.join(
-            os.path.dirname(os.path.abspath("__file__")),
-            "tests",
-            "empty_test_file.zip",
-        )
-        with ZipFile(empty_test_path, 'w') as file:
-            pass
-        test_model.read_queries(empty_test_path)
-        clean_test_folder(empty_test_path)
 
     # test synthetic queries already exists in folder
     with pytest.raises(Exception) as exc_info:

--- a/tests/ml_models/test_sentencetransformermodel_pytest.py
+++ b/tests/ml_models/test_sentencetransformermodel_pytest.py
@@ -123,7 +123,7 @@ def test_missing_files():
 
     # test no tokenizer.json file
     with pytest.raises(Exception) as exc_info:
-        test_model.zip_model()
+        test_model.zip_model(verbose=True)
     assert "Cannot find tokenizer.json file" in str(exc_info.value)
 
     # test no model file
@@ -137,7 +137,7 @@ def test_missing_files():
         test_model3 = SentenceTransformerModel(folder_path=temp_path)
         test_model3.save_as_pt(sentences=["today is sunny"])
         os.remove(os.path.join(temp_path, "msmarco-distilbert-base-tas-b.pt"))
-        test_model3.zip_model()
+        test_model3.zip_model(verbose=True)
         clean_test_folder(temp_path)
     assert "Cannot find model in the model path" in str(exc_info.value)
 

--- a/tests/ml_models/test_sentencetransformermodel_pytest.py
+++ b/tests/ml_models/test_sentencetransformermodel_pytest.py
@@ -8,6 +8,7 @@
 import json
 import os
 import shutil
+from zipfile import ZipFile
 
 import pytest
 
@@ -106,8 +107,19 @@ def test_missing_files():
 
     with pytest.raises(FileNotFoundError):
         test_model.read_queries(read_path="1234")
+        
+    with pytest.raises(Exception) as exc_info:
+        empty_test_path = os.path.join(
+            os.path.dirname(os.path.abspath("__file__")),
+            "tests",
+            "empty_test_file.zip",
+        )
+        with ZipFile(empty_test_path, 'w') as file:
+            pass
+        test_model.read_queries(empty_test_path)
+        clean_test_folder(empty_test_path)
 
-        # test synthetic queries already exists in folder
+    # test synthetic queries already exists in folder
     with pytest.raises(Exception) as exc_info:
         temp_path = os.path.join(
             os.path.dirname(os.path.abspath("__file__")),
@@ -187,7 +199,7 @@ def test_make_model_config_json_for_torch_script():
 
     test_model5.save_as_pt(model_id=model_id, sentences=["today is sunny"])
     model_config_path_torch = test_model5.make_model_config_json(
-        model_format="TORCH_SCRIPT"
+        model_format="TORCH_SCRIPT", verbose=True
     )
     try:
         with open(model_config_path_torch) as json_file:
@@ -368,86 +380,6 @@ def test_overwrite_fields_in_model_config():
             and k == "normalize_result"
             and not v
         )
-
-    clean_test_folder(TEST_FOLDER)
-
-
-def test_missing_fields_in_config_json():
-    model_id = "sentence-transformers/msmarco-distilbert-base-tas-b"
-    expected_model_config_data = {
-        "embedding_dimension": 768,
-        "normalize_result": False,
-    }
-
-    clean_test_folder(TEST_FOLDER)
-    test_model9 = SentenceTransformerModel(
-        folder_path=TEST_FOLDER,
-        model_id=model_id,
-    )
-
-    test_model9.save_as_pt(model_id=model_id, sentences=["today is sunny"])
-
-    pooling_json_file_path = os.path.join(TEST_FOLDER, "1_Pooling", "config.json")
-    try:
-        with open(pooling_json_file_path, "w") as f:
-            empty_dict = {}
-            json.dump(empty_dict, f)
-    except Exception as exec:
-        assert False, f"Modifying pooling json file raised an exception {exec}"
-
-    config_json_file_path = os.path.join(TEST_FOLDER, "config.json")
-    try:
-        with open(config_json_file_path, "r") as f:
-            config_content = json.load(f)
-            embedding_dimension_mapping_list = [
-                "dim",
-                "hidden_size",
-                "d_model",
-            ]
-            for mapping_item in embedding_dimension_mapping_list:
-                config_content.pop(mapping_item, None)
-
-        with open(config_json_file_path, "w") as f:
-            json.dump(config_content, f)
-    except Exception as exec:
-        assert False, f"Modifying config json file raised an exception {exec}"
-
-    model_config_path_torch = test_model9.make_model_config_json(
-        model_format="TORCH_SCRIPT", verbose=True
-    )
-    try:
-        with open(model_config_path_torch) as json_file:
-            model_config_data_torch = json.load(json_file)
-    except Exception as exec:
-        assert (
-            False
-        ), f"Creating model config file for tracing in torch_script raised an exception {exec}"
-
-    assert (
-        "name" in model_config_data_torch
-        and model_config_data_torch["name"] == model_id
-    ), "Missing or Wrong model name in torch script model config file"
-    assert (
-        "model_format" in model_config_data_torch
-        and model_config_data_torch["model_format"] == "TORCH_SCRIPT"
-    )
-    assert (
-        "model_config" in model_config_data_torch
-    ), "Missing 'model_config' in torch script model config file"
-
-    for k, v in expected_model_config_data.items():
-        assert (
-            k in model_config_data_torch["model_config"]
-            and model_config_data_torch["model_config"][k] == v
-        ) or (
-            k not in model_config_data_torch["model_config"]
-            and k == "normalize_result"
-            and not v
-        ), "make_model_config_json() does not generate an expected model config"
-
-    assert (
-        "pooling_mode" not in model_config_data_torch
-    ), "make_model_config_json() does not generate an expected model config"
 
     clean_test_folder(TEST_FOLDER)
 


### PR DESCRIPTION
### Description
Instead of scrapping `embedding_dimension`, `pooling_mode`, and `normalize_result` from config.json file, we can use  sentence transformer attributes and build-in function directly.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
