### PR TITLE
Add description field with make_model_config_json function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Make make_model_config_json function more concise by @thanawan-atc in ([#191](https://github.com/opensearch-project/opensearch-py-ml/pull/191))
 - Enabled auto-truncation for any pretrained models by @Yerzhaisang in ([#192](https://github.com/opensearch-project/opensearch-py-ml/pull/192))
 - Generalize make_model_config_json function by @thanawan-atc in ([#200](https://github.com/opensearch-project/opensearch-py-ml/pull/200))
+- Enable make_model_config_json to add model description to model config file by @thanawan-atc in ([#203](https://github.com/opensearch-project/opensearch-py-ml/pull/203))
 
 ## [1.0.0]    
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # CHANGELOG
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [1.2.0]
+
+### Added
+
+### Changed
+
+### Fixed
+- Enable make_model_config_json to add model description to model config file by @thanawan-atc in ([#203](https://github.com/opensearch-project/opensearch-py-ml/pull/203))
+
 ## [1.1.0]
 
 ### Added
@@ -29,7 +38,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Make make_model_config_json function more concise by @thanawan-atc in ([#191](https://github.com/opensearch-project/opensearch-py-ml/pull/191))
 - Enabled auto-truncation for any pretrained models by @Yerzhaisang in ([#192](https://github.com/opensearch-project/opensearch-py-ml/pull/192))
 - Generalize make_model_config_json function by @thanawan-atc in ([#200](https://github.com/opensearch-project/opensearch-py-ml/pull/200))
-- Enable make_model_config_json to add model description to model config file by @thanawan-atc in ([#203](https://github.com/opensearch-project/opensearch-py-ml/pull/203))
 
 ## [1.0.0]    
 

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -8,6 +8,7 @@ sphinx_rtd_theme
 nbsphinx
 pandoc
 deprecated
+
 # using in SentenceTransformerModel
 torch
 pyyaml
@@ -15,6 +16,7 @@ accelerate
 sentence_transformers
 transformers
 tqdm
+mdutils
 
 # traitlets has been having all sorts of release problems lately.
 traitlets<5.1

--- a/docs/source/examples/demo_tracing_model_torchscript_onnx.ipynb
+++ b/docs/source/examples/demo_tracing_model_torchscript_onnx.ipynb
@@ -51,9 +51,9 @@
    "source": [
     "#!pip install opensearch-py opensearch-py-ml\n",
     "\n",
-    "import os\n",
-    "import sys\n",
-    "sys.path.append(os.path.abspath(os.path.join('../../..')))"
+    "# import os\n",
+    "# import sys\n",
+    "# sys.path.append(os.path.abspath(os.path.join('../../..')))"
    ]
   },
   {
@@ -65,7 +65,16 @@
      "name": "#%%\n"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/linuxbrew/.linuxbrew/opt/python@3.8/lib/python3.8/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "import warnings\n",
     "warnings.filterwarnings('ignore', category=DeprecationWarning)\n",
@@ -161,53 +170,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "id": "c7b0ff7e",
    "metadata": {
     "scrolled": true
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/linuxbrew/.linuxbrew/opt/python@3.8/lib/python3.8/site-packages/transformers/models/distilbert/modeling_distilbert.py:223: TracerWarning: torch.tensor results are registered as constants in the trace. You can safely ignore this warning if you use this function to create tensors out of constant variables that would be the same every time you call this function. In any other case, this might cause the trace to be incorrect.\n",
+      "  mask, torch.tensor(torch.finfo(scores.dtype).min)\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "model file is saved to  sentence-transformers-torchscript/msmarco-distilbert-base-tas-b/multi-qa-MiniLM-L6-cos-v1.pt\n",
-      "zip file is saved to  sentence-transformers-torchscript/msmarco-distilbert-base-tas-b/multi-qa-MiniLM-L6-cos-v1.zip \n",
+      "model file is saved to  sentence-transformers-torchscript/msmarco-distilbert-base-tas-b/msmarco-distilbert-base-tas-b.pt\n",
+      "zip file is saved to  sentence-transformers-torchscript/msmarco-distilbert-base-tas-b/msmarco-distilbert-base-tas-b.zip \n",
       "\n"
      ]
     }
    ],
    "source": [
-    "pre_trained_model = SentenceTransformerModel(model_id=\"sentence-transformers/multi-qa-MiniLM-L6-cos-v1\", folder_path='sentence-transformers-torchscript/msmarco-distilbert-base-tas-b', overwrite=True)\n",
-    "model_path = pre_trained_model.save_as_pt(model_id=\"sentence-transformers/multi-qa-MiniLM-L6-cos-v1\", sentences=[\"for example providing a small sentence\", \"we can add multiple sentences\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "962920f3",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ml-commons_model_config.json file is saved at :  sentence-transformers-onxx/msmarco-distilbert-base-tas-b/ml-commons_model_config.json\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'sentence-transformers-onxx/msmarco-distilbert-base-tas-b/ml-commons_model_config.json'"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pre_trained_model.make_model_config_json()"
+    "pre_trained_model = SentenceTransformerModel(folder_path='sentence-transformers-torchscript/msmarco-distilbert-base-tas-b', overwrite=True)\n",
+    "model_path = pre_trained_model.save_as_pt(model_id=\"sentence-transformers/msmarco-distilbert-base-tas-b\", sentences=[\"for example providing a small sentence\", \"we can add multiple sentences\"])"
    ]
   },
   {
@@ -355,7 +344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "id": "44d6b1d2",
    "metadata": {},
    "outputs": [
@@ -363,298 +352,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
-      "To disable this warning, you can either:\n",
-      "\t- Avoid using `tokenizers` before the fork if possible\n",
-      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "22ac03dbec49480db459cb273b72e474",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)d7125/.gitattributes:   0%|          | 0.00/690 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "92e7910f55ef470781dc3a1385dae576",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)_Pooling/config.json:   0%|          | 0.00/190 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e10408a27c5f4f67a240b90d489e7a78",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)90f41d7125/README.md:   0%|          | 0.00/4.01k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9c24aff409ba41a7ae5f48ac10214821",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)f41d7125/config.json:   0%|          | 0.00/629 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9b728fde15764d229d2bf054f00afbcd",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)ce_transformers.json:   0%|          | 0.00/122 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e88bb31d49db40858618cda1ea45fcba",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading pytorch_model.bin:   0%|          | 0.00/69.6M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9e402a036005479982a12ef6b2b6acdc",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)nce_bert_config.json:   0%|          | 0.00/53.0 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2b717df600f9473baf72abcaeb221912",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)cial_tokens_map.json:   0%|          | 0.00/112 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d7a0ed2c38e4436d835f091b7f34aeea",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)d7125/tokenizer.json:   0%|          | 0.00/466k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "db2e6fa828a44df7891dd6f2edb0b1ab",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)okenizer_config.json:   0%|          | 0.00/314 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a31a5054635b47c280c886b5e23fde32",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)90f41d7125/vocab.txt:   0%|          | 0.00/232k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cc81b88f4f1d426089fe70b50dd3af6c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)41d7125/modules.json:   0%|          | 0.00/229 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "ONNX opset version set to: 15\n",
-      "Loading pipeline (model: sentence-transformers/paraphrase-MiniLM-L3-v2, tokenizer: sentence-transformers/paraphrase-MiniLM-L3-v2)\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d22410d2caff47a48af29615b48c754a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)lve/main/config.json:   0%|          | 0.00/629 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "25d639d634214abf866ad67338e2d717",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading pytorch_model.bin:   0%|          | 0.00/69.6M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7b700a0914cf4b939b2534cc554efd24",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)okenizer_config.json:   0%|          | 0.00/314 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f6f851d0ccd7481390b2e1cb70582556",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)solve/main/vocab.txt:   0%|          | 0.00/232k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "524d02c85ad5426b84619e3a10a3a8fc",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)/main/tokenizer.json:   0%|          | 0.00/466k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "83da56b2e5de4f058bdf8df355a3dc93",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (…)cial_tokens_map.json:   0%|          | 0.00/112 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Loading pipeline (model: sentence-transformers/msmarco-distilbert-base-tas-b, tokenizer: sentence-transformers/msmarco-distilbert-base-tas-b)\n",
       "Creating folder sentence-transformers-onxx/msmarco-distilbert-base-tas-b/onnx\n",
-      "Using framework PyTorch: 2.0.1\n",
+      "Using framework PyTorch: 1.13.1+cu117\n",
       "Found input input_ids with shape: {0: 'batch', 1: 'sequence'}\n",
-      "Found input token_type_ids with shape: {0: 'batch', 1: 'sequence'}\n",
       "Found input attention_mask with shape: {0: 'batch', 1: 'sequence'}\n",
       "Found output output_0 with shape: {0: 'batch', 1: 'sequence'}\n",
-      "Found output output_1 with shape: {0: 'batch'}\n",
       "Ensuring inputs are in correct order\n",
-      "position_ids is not present in the generated input list.\n",
-      "Generated inputs order: ['input_ids', 'attention_mask', 'token_type_ids']\n",
-      "================ Diagnostic Run torch.onnx.export version 2.0.1 ================\n",
-      "verbose: False, log level: Level.ERROR\n",
-      "======================= 0 NONE 0 NOTE 0 WARNING 0 ERROR ========================\n",
-      "\n",
-      "zip file is saved to  sentence-transformers-onxx/msmarco-distilbert-base-tas-b/paraphrase-MiniLM-L3-v2.zip \n",
+      "head_mask is not present in the generated input list.\n",
+      "Generated inputs order: ['input_ids', 'attention_mask']\n",
+      "zip file is saved to  sentence-transformers-onxx/msmarco-distilbert-base-tas-b/msmarco-distilbert-base-tas-b.zip \n",
       "\n"
      ]
     }
    ],
    "source": [
-    "pre_trained_model = SentenceTransformerModel(model_id=\"sentence-transformers/paraphrase-MiniLM-L3-v2\", folder_path='sentence-transformers-onxx/msmarco-distilbert-base-tas-b', overwrite=True)\n",
-    "model_path_onnx = pre_trained_model.save_as_onnx(model_id=\"sentence-transformers/paraphrase-MiniLM-L3-v2\")"
+    "pre_trained_model = SentenceTransformerModel(folder_path='sentence-transformers-onxx/msmarco-distilbert-base-tas-b', overwrite=True)\n",
+    "model_path_onnx = pre_trained_model.save_as_onnx(model_id=\"sentence-transformers/msmarco-distilbert-base-tas-b\")"
    ]
   },
   {
@@ -846,7 +561,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.8.17"
   }
  },
  "nbformat": 4,

--- a/docs/source/examples/demo_tracing_model_torchscript_onnx.ipynb
+++ b/docs/source/examples/demo_tracing_model_torchscript_onnx.ipynb
@@ -51,9 +51,9 @@
    "source": [
     "#!pip install opensearch-py opensearch-py-ml\n",
     "\n",
-    "# import os\n",
-    "# import sys\n",
-    "# sys.path.append(os.path.abspath(os.path.join('../../..')))"
+    "import os\n",
+    "import sys\n",
+    "sys.path.append(os.path.abspath(os.path.join('../../..')))"
    ]
   },
   {
@@ -65,16 +65,7 @@
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/linuxbrew/.linuxbrew/opt/python@3.8/lib/python3.8/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import warnings\n",
     "warnings.filterwarnings('ignore', category=DeprecationWarning)\n",
@@ -170,33 +161,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "id": "c7b0ff7e",
    "metadata": {
     "scrolled": true
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/linuxbrew/.linuxbrew/opt/python@3.8/lib/python3.8/site-packages/transformers/models/distilbert/modeling_distilbert.py:223: TracerWarning: torch.tensor results are registered as constants in the trace. You can safely ignore this warning if you use this function to create tensors out of constant variables that would be the same every time you call this function. In any other case, this might cause the trace to be incorrect.\n",
-      "  mask, torch.tensor(torch.finfo(scores.dtype).min)\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "model file is saved to  sentence-transformers-torchscript/msmarco-distilbert-base-tas-b/msmarco-distilbert-base-tas-b.pt\n",
-      "zip file is saved to  sentence-transformers-torchscript/msmarco-distilbert-base-tas-b/msmarco-distilbert-base-tas-b.zip \n",
+      "model file is saved to  sentence-transformers-torchscript/msmarco-distilbert-base-tas-b/multi-qa-MiniLM-L6-cos-v1.pt\n",
+      "zip file is saved to  sentence-transformers-torchscript/msmarco-distilbert-base-tas-b/multi-qa-MiniLM-L6-cos-v1.zip \n",
       "\n"
      ]
     }
    ],
    "source": [
-    "pre_trained_model = SentenceTransformerModel(folder_path='sentence-transformers-torchscript/msmarco-distilbert-base-tas-b', overwrite=True)\n",
-    "model_path = pre_trained_model.save_as_pt(model_id=\"sentence-transformers/msmarco-distilbert-base-tas-b\", sentences=[\"for example providing a small sentence\", \"we can add multiple sentences\"])"
+    "pre_trained_model = SentenceTransformerModel(model_id=\"sentence-transformers/multi-qa-MiniLM-L6-cos-v1\", folder_path='sentence-transformers-torchscript/msmarco-distilbert-base-tas-b', overwrite=True)\n",
+    "model_path = pre_trained_model.save_as_pt(model_id=\"sentence-transformers/multi-qa-MiniLM-L6-cos-v1\", sentences=[\"for example providing a small sentence\", \"we can add multiple sentences\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "962920f3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ml-commons_model_config.json file is saved at :  sentence-transformers-onxx/msmarco-distilbert-base-tas-b/ml-commons_model_config.json\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'sentence-transformers-onxx/msmarco-distilbert-base-tas-b/ml-commons_model_config.json'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pre_trained_model.make_model_config_json()"
    ]
   },
   {
@@ -344,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "id": "44d6b1d2",
    "metadata": {},
    "outputs": [
@@ -352,24 +363,298 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "22ac03dbec49480db459cb273b72e474",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)d7125/.gitattributes:   0%|          | 0.00/690 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "92e7910f55ef470781dc3a1385dae576",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)_Pooling/config.json:   0%|          | 0.00/190 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e10408a27c5f4f67a240b90d489e7a78",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)90f41d7125/README.md:   0%|          | 0.00/4.01k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9c24aff409ba41a7ae5f48ac10214821",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)f41d7125/config.json:   0%|          | 0.00/629 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9b728fde15764d229d2bf054f00afbcd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)ce_transformers.json:   0%|          | 0.00/122 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e88bb31d49db40858618cda1ea45fcba",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading pytorch_model.bin:   0%|          | 0.00/69.6M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9e402a036005479982a12ef6b2b6acdc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)nce_bert_config.json:   0%|          | 0.00/53.0 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2b717df600f9473baf72abcaeb221912",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)cial_tokens_map.json:   0%|          | 0.00/112 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d7a0ed2c38e4436d835f091b7f34aeea",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)d7125/tokenizer.json:   0%|          | 0.00/466k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "db2e6fa828a44df7891dd6f2edb0b1ab",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)okenizer_config.json:   0%|          | 0.00/314 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a31a5054635b47c280c886b5e23fde32",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)90f41d7125/vocab.txt:   0%|          | 0.00/232k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cc81b88f4f1d426089fe70b50dd3af6c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)41d7125/modules.json:   0%|          | 0.00/229 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "ONNX opset version set to: 15\n",
-      "Loading pipeline (model: sentence-transformers/msmarco-distilbert-base-tas-b, tokenizer: sentence-transformers/msmarco-distilbert-base-tas-b)\n",
+      "Loading pipeline (model: sentence-transformers/paraphrase-MiniLM-L3-v2, tokenizer: sentence-transformers/paraphrase-MiniLM-L3-v2)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d22410d2caff47a48af29615b48c754a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)lve/main/config.json:   0%|          | 0.00/629 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "25d639d634214abf866ad67338e2d717",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading pytorch_model.bin:   0%|          | 0.00/69.6M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7b700a0914cf4b939b2534cc554efd24",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)okenizer_config.json:   0%|          | 0.00/314 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f6f851d0ccd7481390b2e1cb70582556",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)solve/main/vocab.txt:   0%|          | 0.00/232k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "524d02c85ad5426b84619e3a10a3a8fc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)/main/tokenizer.json:   0%|          | 0.00/466k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "83da56b2e5de4f058bdf8df355a3dc93",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (…)cial_tokens_map.json:   0%|          | 0.00/112 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Creating folder sentence-transformers-onxx/msmarco-distilbert-base-tas-b/onnx\n",
-      "Using framework PyTorch: 1.13.1+cu117\n",
+      "Using framework PyTorch: 2.0.1\n",
       "Found input input_ids with shape: {0: 'batch', 1: 'sequence'}\n",
+      "Found input token_type_ids with shape: {0: 'batch', 1: 'sequence'}\n",
       "Found input attention_mask with shape: {0: 'batch', 1: 'sequence'}\n",
       "Found output output_0 with shape: {0: 'batch', 1: 'sequence'}\n",
+      "Found output output_1 with shape: {0: 'batch'}\n",
       "Ensuring inputs are in correct order\n",
-      "head_mask is not present in the generated input list.\n",
-      "Generated inputs order: ['input_ids', 'attention_mask']\n",
-      "zip file is saved to  sentence-transformers-onxx/msmarco-distilbert-base-tas-b/msmarco-distilbert-base-tas-b.zip \n",
+      "position_ids is not present in the generated input list.\n",
+      "Generated inputs order: ['input_ids', 'attention_mask', 'token_type_ids']\n",
+      "================ Diagnostic Run torch.onnx.export version 2.0.1 ================\n",
+      "verbose: False, log level: Level.ERROR\n",
+      "======================= 0 NONE 0 NOTE 0 WARNING 0 ERROR ========================\n",
+      "\n",
+      "zip file is saved to  sentence-transformers-onxx/msmarco-distilbert-base-tas-b/paraphrase-MiniLM-L3-v2.zip \n",
       "\n"
      ]
     }
    ],
    "source": [
-    "pre_trained_model = SentenceTransformerModel(folder_path='sentence-transformers-onxx/msmarco-distilbert-base-tas-b', overwrite=True)\n",
-    "model_path_onnx = pre_trained_model.save_as_onnx(model_id=\"sentence-transformers/msmarco-distilbert-base-tas-b\")"
+    "pre_trained_model = SentenceTransformerModel(model_id=\"sentence-transformers/paraphrase-MiniLM-L3-v2\", folder_path='sentence-transformers-onxx/msmarco-distilbert-base-tas-b', overwrite=True)\n",
+    "model_path_onnx = pre_trained_model.save_as_onnx(model_id=\"sentence-transformers/paraphrase-MiniLM-L3-v2\")"
    ]
   },
   {
@@ -561,7 +846,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.17"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/opensearch_py_ml/ml_models/sentencetransformermodel.py
+++ b/opensearch_py_ml/ml_models/sentencetransformermodel.py
@@ -1012,26 +1012,26 @@ class SentenceTransformerModel:
         """
         Get description of the model from README.md file
         after the model is saved in local directory
-        
+
         This function assumes that the md file has the following format in the README.md:
 
         # sentence-transformers/msmarco-distilbert-base-tas-b
-        This is a port of the DistilBert TAS-B Model to sentence-transformers model: 
-        It maps sentences & paragraphs to a 768 dimensional dense vector space and 
+        This is a port of the DistilBert TAS-B Model to sentence-transformers model:
+        It maps sentences & paragraphs to a 768 dimensional dense vector space and
         is optimized for the task of semantic search.
-        
+
         # Usage (Sentence-Transformers)
         ...
-         
+
         where "# MODEL_ID" is the first line that starts with #.
-        
+
         :param readme_file_path: Path to README.md file
         :type readme_file_path: string
         :return: Description of the model
         :rtype: string
         """
         readme_data = MarkDownFile.read_file(readme_file_path)
-        
+
         # Find the description section
         start_str = f"# {self.model_id}"
         start = readme_data.find(start_str)
@@ -1040,24 +1040,24 @@ class SentenceTransformerModel:
             start_str = f"# {model_name}"
             start = readme_data.find(start_str)
         end = readme_data.find("## ", start)
-        
+
         # If we cannot find the scope of description section, raise error.
         if start == -1 or end == -1:
             assert False, "Cannot find description in README.md file"
 
         # Parse out the description section
         description = readme_data[start + len(start_str) + 1 : end].strip()
-        
+
         # Remove hyperlink and reformat text
         description = re.sub(r"\(.*?\)", "", description)
         description = re.sub(r"[\[\]]", "", description)
         description = re.sub(r"\*", "", description)
-        
+
         # Remove unnecessary part if exists(e.g. " For an introduction to ..."
         unnecessary_part = description.find(" For an introduction to")
         if unnecessary_part != -1:
             description = description[:unnecessary_part]
-            
+
         return description
 
     def make_model_config_json(

--- a/opensearch_py_ml/ml_models/sentencetransformermodel.py
+++ b/opensearch_py_ml/ml_models/sentencetransformermodel.py
@@ -1070,7 +1070,10 @@ class SentenceTransformerModel:
         :return: Description of the model
         :rtype: string
         """
-        description = f"This is a sentence-transformers model: It maps sentences & paragraphs to a {embedding_dimension} dimensional dense vector space"
+        print(
+            "Using default description from embedding_dimension instead (You can overwrite this by specifying description parameter in make_model_config_json function"
+        )
+        description = f"This is a sentence-transformers model: It maps sentences & paragraphs to a {embedding_dimension} dimensional dense vector space."
         return description
 
     def make_model_config_json(
@@ -1165,15 +1168,16 @@ class SentenceTransformerModel:
                     if verbose:
                         print("reading README.md file")
                     description = self._get_model_description_from_readme_file(
-                        embedding_dimension
+                        readme_file_path
                     )
                 except Exception as e:
+                    print(f"Cannot scrape model description from README.md file: {e}")
                     description = self._generate_default_model_description(
                         embedding_dimension
                     )
-                    print(f"Cannot get model description from README.md file: {e}")
             else:
-                description = self.__generate_default_model_description(
+                print("Cannot find README.md file to scrape model description")
+                description = self._generate_default_model_description(
                     embedding_dimension
                 )
 

--- a/opensearch_py_ml/ml_models/sentencetransformermodel.py
+++ b/opensearch_py_ml/ml_models/sentencetransformermodel.py
@@ -10,6 +10,7 @@ import os
 import pickle
 import platform
 import random
+import re
 import shutil
 import subprocess
 import time
@@ -23,6 +24,7 @@ import pandas as pd
 import torch
 import yaml
 from accelerate import Accelerator, notebook_launcher
+from mdutils.fileutils import MarkDownFile
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.models import Normalize, Pooling, Transformer
 from torch.utils.data import DataLoader
@@ -1006,6 +1008,36 @@ class SentenceTransformerModel:
                 "Failed to open config file for ml common upload: " + file_path + "\n"
             )
 
+    def get_model_description_from_md_file(self, readme_file_path) -> str:
+        """
+        Get description of the model from README.md file
+        after the model is saved in local directory
+
+        :param readme_file_path: Path to README.md file
+        :type readme_file_path: string
+        :return: Description of the model
+        :rtype: string
+        """
+        readme_data = MarkDownFile.read_file(readme_file_path)
+        start_str = f"# {self.model_id}"
+        start = readme_data.find(start_str)
+        if start == -1:
+            model_name = self.model_id.split("/")[1]
+            start_str = f"# {model_name}"
+            start = readme_data.find(start_str)
+        end = readme_data.find("## ", start)
+        if start == -1 or end == -1:
+            assert False, "Cannot find description in README.md file"
+
+        description = readme_data[start + len(start_str) + 1 : end].strip()
+        description = re.sub(r"\(.*?\)", "", description)
+        description = re.sub(r"[\[\]]", "", description)
+        description = re.sub(r"\*", "", description)
+        unnecessary_part = description.find(" For an introduction to")
+        if unnecessary_part != -1:
+            description = description[:unnecessary_part]
+        return description
+
     def make_model_config_json(
         self,
         model_name: str = None,
@@ -1014,6 +1046,7 @@ class SentenceTransformerModel:
         embedding_dimension: int = None,
         pooling_mode: str = None,
         normalize_result: bool = None,
+        description: str = None,
         all_config: str = None,
         model_type: str = None,
         verbose: bool = False,
@@ -1040,6 +1073,9 @@ class SentenceTransformerModel:
         :param normalize_result: Optional, whether to normalize the result of the model. If None, check from the pre-trained
         hugging-face model object.
         :type normalize_result: bool
+        :param description: Optional, the description of the model. If None, get description from the README.md
+            file in the model folder.
+        :type description: str
         :param all_config:
             Optional, the all_config of the model. If None, parse all contents from the config file of pre-trained
             hugging-face model
@@ -1087,6 +1123,18 @@ class SentenceTransformerModel:
                     f"Raised exception while getting model data from pre-trained hugging-face model object: {e}"
                 )
 
+        if description is None:
+            readme_file_path = os.path.join(self.folder_path, "README.md")
+            if os.path.exists(readme_file_path):
+                try:
+                    if verbose:
+                        print("reading README.md file")
+                    description = self.get_model_description_from_md_file(
+                        readme_file_path
+                    )
+                except Exception as e:
+                    print(f"Cannot get model description from README.md file: {e}")
+
         if all_config is None:
             if not os.path.exists(config_json_file_path):
                 raise Exception(
@@ -1125,6 +1173,9 @@ class SentenceTransformerModel:
                 "all_config": json.dumps(all_config),
             },
         }
+
+        if description is not None:
+            model_config_content["description"] = description
 
         if verbose:
             print("generating ml-commons_model_config.json file...\n")

--- a/opensearch_py_ml/ml_models/sentencetransformermodel.py
+++ b/opensearch_py_ml/ml_models/sentencetransformermodel.py
@@ -1016,14 +1016,10 @@ class SentenceTransformerModel:
         This function assumes that the md file has the following format in the README.md:
 
         # sentence-transformers/msmarco-distilbert-base-tas-b
-        This is a port of the DistilBert TAS-B Model to sentence-transformers model:
-        It maps sentences & paragraphs to a 768 dimensional dense vector space and
-        is optimized for the task of semantic search.
+        This is [ ... further description ... ]
 
-        # Usage (Sentence-Transformers)
+        # [ ... Next section ...]
         ...
-
-        where "# MODEL_ID" is the first line that starts with #.
 
         :param readme_file_path: Path to README.md file
         :type readme_file_path: string
@@ -1047,6 +1043,9 @@ class SentenceTransformerModel:
 
         # Parse out the description section
         description = readme_data[start + len(start_str) + 1 : end].strip()
+        description = description.split('\n')[0]
+        if not description.startswith('This is'):
+            assert False, "Cannot find description that starts with 'This is' in README.md file"
 
         # Remove hyperlink and reformat text
         description = re.sub(r"\(.*?\)", "", description)

--- a/opensearch_py_ml/ml_models/sentencetransformermodel.py
+++ b/opensearch_py_ml/ml_models/sentencetransformermodel.py
@@ -1043,9 +1043,11 @@ class SentenceTransformerModel:
 
         # Parse out the description section
         description = readme_data[start + len(start_str) + 1 : end].strip()
-        description = description.split('\n')[0]
-        if not description.startswith('This is'):
-            assert False, "Cannot find description that starts with 'This is' in README.md file"
+        description = description.split("\n")[0]
+        if not description.startswith("This is"):
+            assert (
+                False
+            ), "Cannot find description that starts with 'This is' in README.md file"
 
         # Remove hyperlink and reformat text
         description = re.sub(r"\(.*?\)", "", description)

--- a/opensearch_py_ml/ml_models/sentencetransformermodel.py
+++ b/opensearch_py_ml/ml_models/sentencetransformermodel.py
@@ -1008,17 +1008,31 @@ class SentenceTransformerModel:
                 "Failed to open config file for ml common upload: " + file_path + "\n"
             )
 
-    def get_model_description_from_md_file(self, readme_file_path) -> str:
+    def _get_model_description_from_md_file(self, readme_file_path) -> str:
         """
         Get description of the model from README.md file
         after the model is saved in local directory
+        
+        This function assumes that the md file has the following format in the README.md:
 
+        # sentence-transformers/msmarco-distilbert-base-tas-b
+        This is a port of the DistilBert TAS-B Model to sentence-transformers model: 
+        It maps sentences & paragraphs to a 768 dimensional dense vector space and 
+        is optimized for the task of semantic search.
+        
+        # Usage (Sentence-Transformers)
+        ...
+         
+        where "# MODEL_ID" is the first line that starts with #.
+        
         :param readme_file_path: Path to README.md file
         :type readme_file_path: string
         :return: Description of the model
         :rtype: string
         """
         readme_data = MarkDownFile.read_file(readme_file_path)
+        
+        # Find the description section
         start_str = f"# {self.model_id}"
         start = readme_data.find(start_str)
         if start == -1:
@@ -1026,16 +1040,24 @@ class SentenceTransformerModel:
             start_str = f"# {model_name}"
             start = readme_data.find(start_str)
         end = readme_data.find("## ", start)
+        
+        # If we cannot find the scope of description section, raise error.
         if start == -1 or end == -1:
             assert False, "Cannot find description in README.md file"
 
+        # Parse out the description section
         description = readme_data[start + len(start_str) + 1 : end].strip()
+        
+        # Remove hyperlink and reformat text
         description = re.sub(r"\(.*?\)", "", description)
         description = re.sub(r"[\[\]]", "", description)
         description = re.sub(r"\*", "", description)
+        
+        # Remove unnecessary part if exists(e.g. " For an introduction to ..."
         unnecessary_part = description.find(" For an introduction to")
         if unnecessary_part != -1:
             description = description[:unnecessary_part]
+            
         return description
 
     def make_model_config_json(
@@ -1129,7 +1151,7 @@ class SentenceTransformerModel:
                 try:
                     if verbose:
                         print("reading README.md file")
-                    description = self.get_model_description_from_md_file(
+                    description = self._get_model_description_from_md_file(
                         readme_file_path
                     )
                 except Exception as e:

--- a/opensearch_py_ml/ml_models/sentencetransformermodel.py
+++ b/opensearch_py_ml/ml_models/sentencetransformermodel.py
@@ -1035,7 +1035,7 @@ class SentenceTransformerModel:
             model_name = self.model_id.split("/")[1]
             start_str = f"# {model_name}"
             start = readme_data.find(start_str)
-        end = readme_data.find("# ", start + len(start_str))
+        end = readme_data.find("\n#", start + len(start_str))
 
         # If we cannot find the scope of description section, raise error.
         if start == -1 or end == -1:

--- a/opensearch_py_ml/ml_models/sentencetransformermodel.py
+++ b/opensearch_py_ml/ml_models/sentencetransformermodel.py
@@ -1035,7 +1035,7 @@ class SentenceTransformerModel:
             model_name = self.model_id.split("/")[1]
             start_str = f"# {model_name}"
             start = readme_data.find(start_str)
-        end = readme_data.find("## ", start)
+        end = readme_data.find("# ", start + len(start_str))
 
         # If we cannot find the scope of description section, raise error.
         if start == -1 or end == -1:
@@ -1044,10 +1044,6 @@ class SentenceTransformerModel:
         # Parse out the description section
         description = readme_data[start + len(start_str) + 1 : end].strip()
         description = description.split("\n")[0]
-        if not description.startswith("This is"):
-            assert (
-                False
-            ), "Cannot find description that starts with 'This is' in README.md file"
 
         # Remove hyperlink and reformat text
         description = re.sub(r"\(.*?\)", "", description)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ sentence_transformers
 tqdm
 transformers
 deprecated
+mdutils
 
 #
 # Testing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,7 @@ class SymmetricAPIChecker:
 
     def check_exception(self, ed_exc, pd_exc):
         """Checks that either an exception was raised or not from both opensearch_py_ml and pandas"""
-        assert (ed_exc is None) == (pd_exc is None) and type(ed_exc) == type(pd_exc)
+        assert (ed_exc is None) == (pd_exc is None) and isinstance(ed_exc, type(pd_exc))
         if pd_exc is not None:
             raise pd_exc
 

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -68,8 +68,8 @@ clean_test_folder(TEST_FOLDER)
 
 
 def test_init():
-    assert type(ml_client._client) == OpenSearch
-    assert type(ml_client._model_uploader) == ModelUploader
+    assert isinstance(ml_client._client, OpenSearch)
+    assert isinstance(ml_client._model_uploader, ModelUploader)
 
 
 def test_execute():

--- a/tests/ml_models/test_sentencetransformermodel_pytest.py
+++ b/tests/ml_models/test_sentencetransformermodel_pytest.py
@@ -443,9 +443,11 @@ def test_missing_expected_description_in_readme_file():
     assert (
         "description" not in model_config_data_torch
     ), "Should not have description in model config file"
-    
+
     with open(temp_path, "w") as f:
-        f.write("# sentence-transformers/msmarco-distilbert-base-tas-b\n\nNothing\n\n## Usage (Sentence-Transformers)")
+        f.write(
+            "# sentence-transformers/msmarco-distilbert-base-tas-b\n\nNothing\n\n## Usage (Sentence-Transformers)"
+        )
     model_config_path_torch = test_model10.make_model_config_json(
         model_format="TORCH_SCRIPT"
     )
@@ -491,7 +493,7 @@ def test_overwrite_description():
 
     clean_test_folder(TEST_FOLDER)
 
-    
+
 def test_long_description():
     model_id = "sentence-transformers/gtr-t5-base"
     clean_test_folder(TEST_FOLDER)
@@ -501,7 +503,9 @@ def test_long_description():
     )
 
     test_model12.save_as_pt(model_id=model_id, sentences=["today is sunny"])
-    model_config_path_torch = test_model11.make_model_config_json(model_format="TORCH_SCRIPT")
+    model_config_path_torch = test_model12.make_model_config_json(
+        model_format="TORCH_SCRIPT"
+    )
     try:
         with open(model_config_path_torch) as json_file:
             model_config_data_torch = json.load(json_file)
@@ -509,7 +513,7 @@ def test_long_description():
         assert (
             False
         ), f"Creating model config file for tracing in torch_script raised an exception {exec}"
-    
+
     assert (
         "description" in model_config_data_torch
         and model_config_data_torch["description"]
@@ -518,7 +522,7 @@ def test_long_description():
 
     clean_test_folder(TEST_FOLDER)
 
-    
+
 def test_truncation_parameter():
     model_id = "sentence-transformers/msmarco-distilbert-base-tas-b"
     MAX_LENGTH_TASB = 512

--- a/tests/ml_models/test_sentencetransformermodel_pytest.py
+++ b/tests/ml_models/test_sentencetransformermodel_pytest.py
@@ -382,7 +382,7 @@ def test_overwrite_fields_in_model_config():
     clean_test_folder(TEST_FOLDER)
 
 
-def test_missing_readme_md_files():
+def test_missing_readme_md_file():
     model_id = "sentence-transformers/msmarco-distilbert-base-tas-b"
     clean_test_folder(TEST_FOLDER)
     test_model9 = SentenceTransformerModel(
@@ -414,7 +414,7 @@ def test_missing_readme_md_files():
     clean_test_folder(TEST_FOLDER)
 
 
-def test_overwrite_description():
+def missing_description_in_readme_file():
     model_id = "sentence-transformers/msmarco-distilbert-base-tas-b"
     clean_test_folder(TEST_FOLDER)
     test_model10 = SentenceTransformerModel(
@@ -423,7 +423,40 @@ def test_overwrite_description():
     )
 
     test_model10.save_as_pt(model_id=model_id, sentences=["today is sunny"])
+    temp_path = os.path.join(
+        TEST_FOLDER,
+        "README.md",
+    )
+    with open(temp_path, "w") as f:
+        f.write("No model description here")
     model_config_path_torch = test_model10.make_model_config_json(
+        model_format="TORCH_SCRIPT"
+    )
+    try:
+        with open(model_config_path_torch) as json_file:
+            model_config_data_torch = json.load(json_file)
+    except Exception as exec:
+        assert (
+            False
+        ), f"Creating model config file for tracing in torch_script raised an exception {exec}"
+
+    assert (
+        "description" not in model_config_data_torch
+    ), "Should not have description in model config file"
+
+    clean_test_folder(TEST_FOLDER)
+
+
+def test_overwrite_description():
+    model_id = "sentence-transformers/msmarco-distilbert-base-tas-b"
+    clean_test_folder(TEST_FOLDER)
+    test_model11 = SentenceTransformerModel(
+        folder_path=TEST_FOLDER,
+        model_id=model_id,
+    )
+
+    test_model11.save_as_pt(model_id=model_id, sentences=["today is sunny"])
+    model_config_path_torch = test_model11.make_model_config_json(
         model_format="TORCH_SCRIPT", description="Expected Description"
     )
     try:
@@ -447,12 +480,12 @@ def test_truncation_parameter():
     MAX_LENGTH_TASB = 512
 
     clean_test_folder(TEST_FOLDER)
-    test_model11 = SentenceTransformerModel(
+    test_model12 = SentenceTransformerModel(
         folder_path=TEST_FOLDER,
         model_id=model_id,
     )
 
-    test_model11.save_as_pt(model_id=model_id, sentences=["today is sunny"])
+    test_model12.save_as_pt(model_id=model_id, sentences=["today is sunny"])
 
     tokenizer_json_file_path = os.path.join(TEST_FOLDER, "tokenizer.json")
     try:

--- a/tests/ml_models/test_sentencetransformermodel_pytest.py
+++ b/tests/ml_models/test_sentencetransformermodel_pytest.py
@@ -262,7 +262,7 @@ def test_make_model_config_json_for_onnx():
         "description" in model_config_data_onnx
         and model_config_data_onnx["description"]
         == "This is a sentence-transformers model: It maps sentences & paragraphs to a 384 dimensional dense vector space and can be used for tasks like clustering or semantic search."
-    ), "Missing or Wrong model description in onnx model config file'"
+    ), "Missing or Wrong model description in onnx model config file"
     assert (
         "model_config" in model_config_data_onnx
     ), "Missing 'model_config' in onnx model config file"
@@ -414,7 +414,7 @@ def test_missing_readme_md_file():
     clean_test_folder(TEST_FOLDER)
 
 
-def test_missing_description_in_readme_file():
+def test_missing_expected_description_in_readme_file():
     model_id = "sentence-transformers/msmarco-distilbert-base-tas-b"
     clean_test_folder(TEST_FOLDER)
     test_model10 = SentenceTransformerModel(
@@ -429,6 +429,23 @@ def test_missing_description_in_readme_file():
     )
     with open(temp_path, "w") as f:
         f.write("No model description here")
+    model_config_path_torch = test_model10.make_model_config_json(
+        model_format="TORCH_SCRIPT"
+    )
+    try:
+        with open(model_config_path_torch) as json_file:
+            model_config_data_torch = json.load(json_file)
+    except Exception as exec:
+        assert (
+            False
+        ), f"Creating model config file for tracing in torch_script raised an exception {exec}"
+
+    assert (
+        "description" not in model_config_data_torch
+    ), "Should not have description in model config file"
+    
+    with open(temp_path, "w") as f:
+        f.write("# sentence-transformers/msmarco-distilbert-base-tas-b\n\nNothing\n\n## Usage (Sentence-Transformers)")
     model_config_path_torch = test_model10.make_model_config_json(
         model_format="TORCH_SCRIPT"
     )
@@ -474,11 +491,9 @@ def test_overwrite_description():
 
     clean_test_folder(TEST_FOLDER)
 
-
-def test_truncation_parameter():
-    model_id = "sentence-transformers/msmarco-distilbert-base-tas-b"
-    MAX_LENGTH_TASB = 512
-
+    
+def test_long_description():
+    model_id = "sentence-transformers/gtr-t5-base"
     clean_test_folder(TEST_FOLDER)
     test_model12 = SentenceTransformerModel(
         folder_path=TEST_FOLDER,
@@ -486,6 +501,35 @@ def test_truncation_parameter():
     )
 
     test_model12.save_as_pt(model_id=model_id, sentences=["today is sunny"])
+    model_config_path_torch = test_model11.make_model_config_json(model_format="TORCH_SCRIPT")
+    try:
+        with open(model_config_path_torch) as json_file:
+            model_config_data_torch = json.load(json_file)
+    except Exception as exec:
+        assert (
+            False
+        ), f"Creating model config file for tracing in torch_script raised an exception {exec}"
+    
+    assert (
+        "description" in model_config_data_torch
+        and model_config_data_torch["description"]
+        == "This is a sentence-transformers model: It maps sentences & paragraphs to a 768 dimensional dense vector space. The model was specifically trained for the task of sematic search."
+    ), "Missing or Wrong model description in torch_script model config file"
+
+    clean_test_folder(TEST_FOLDER)
+
+    
+def test_truncation_parameter():
+    model_id = "sentence-transformers/msmarco-distilbert-base-tas-b"
+    MAX_LENGTH_TASB = 512
+
+    clean_test_folder(TEST_FOLDER)
+    test_model13 = SentenceTransformerModel(
+        folder_path=TEST_FOLDER,
+        model_id=model_id,
+    )
+
+    test_model13.save_as_pt(model_id=model_id, sentences=["today is sunny"])
 
     tokenizer_json_file_path = os.path.join(TEST_FOLDER, "tokenizer.json")
     try:

--- a/tests/ml_models/test_sentencetransformermodel_pytest.py
+++ b/tests/ml_models/test_sentencetransformermodel_pytest.py
@@ -414,7 +414,7 @@ def test_missing_readme_md_file():
     clean_test_folder(TEST_FOLDER)
 
 
-def missing_description_in_readme_file():
+def test_missing_description_in_readme_file():
     model_id = "sentence-transformers/msmarco-distilbert-base-tas-b"
     clean_test_folder(TEST_FOLDER)
     test_model10 = SentenceTransformerModel(

--- a/tests/ml_models/test_sentencetransformermodel_pytest.py
+++ b/tests/ml_models/test_sentencetransformermodel_pytest.py
@@ -393,7 +393,6 @@ def test_missing_readme_md_files():
     test_model9.save_as_pt(model_id=model_id, sentences=["today is sunny"])
     temp_path = os.path.join(
         TEST_FOLDER,
-        "tests",
         "REAMD.md",
     )
     os.remove(temp_path)

--- a/tests/ml_models/test_sentencetransformermodel_pytest.py
+++ b/tests/ml_models/test_sentencetransformermodel_pytest.py
@@ -444,25 +444,6 @@ def test_missing_expected_description_in_readme_file():
         "description" not in model_config_data_torch
     ), "Should not have description in model config file"
 
-    with open(temp_path, "w") as f:
-        f.write(
-            "# sentence-transformers/msmarco-distilbert-base-tas-b\n\nNothing\n\n## Usage (Sentence-Transformers)"
-        )
-    model_config_path_torch = test_model10.make_model_config_json(
-        model_format="TORCH_SCRIPT"
-    )
-    try:
-        with open(model_config_path_torch) as json_file:
-            model_config_data_torch = json.load(json_file)
-    except Exception as exec:
-        assert (
-            False
-        ), f"Creating model config file for tracing in torch_script raised an exception {exec}"
-
-    assert (
-        "description" not in model_config_data_torch
-    ), "Should not have description in model config file"
-
     clean_test_folder(TEST_FOLDER)
 
 

--- a/tests/ml_models/test_sentencetransformermodel_pytest.py
+++ b/tests/ml_models/test_sentencetransformermodel_pytest.py
@@ -393,7 +393,7 @@ def test_missing_readme_md_files():
     test_model9.save_as_pt(model_id=model_id, sentences=["today is sunny"])
     temp_path = os.path.join(
         TEST_FOLDER,
-        "REAMD.md",
+        "README.md",
     )
     os.remove(temp_path)
     model_config_path_torch = test_model9.make_model_config_json(
@@ -408,7 +408,7 @@ def test_missing_readme_md_files():
         ), f"Creating model config file for tracing in torch_script raised an exception {exec}"
 
     assert (
-        "description" in model_config_data_torch
+        "description" not in model_config_data_torch
     ), "Should not have description in model config file"
 
     clean_test_folder(TEST_FOLDER)

--- a/tests/ml_models/test_sentencetransformermodel_pytest.py
+++ b/tests/ml_models/test_sentencetransformermodel_pytest.py
@@ -408,14 +408,16 @@ def test_missing_readme_md_file():
         ), f"Creating model config file for tracing in torch_script raised an exception {exec}"
 
     assert (
-        "description" not in model_config_data_torch
-    ), "Should not have description in model config file"
+        "description" in model_config_data_torch
+        and model_config_data_torch["description"]
+        == "This is a sentence-transformers model: It maps sentences & paragraphs to a 768 dimensional dense vector space."
+    ), "Should use default model description when README.md file is missing"
 
     clean_test_folder(TEST_FOLDER)
 
 
 def test_missing_expected_description_in_readme_file():
-    model_id = "sentence-transformers/msmarco-distilbert-base-tas-b"
+    model_id = "sentence-transformers/paraphrase-MiniLM-L3-v2"
     clean_test_folder(TEST_FOLDER)
     test_model10 = SentenceTransformerModel(
         folder_path=TEST_FOLDER,
@@ -441,8 +443,10 @@ def test_missing_expected_description_in_readme_file():
         ), f"Creating model config file for tracing in torch_script raised an exception {exec}"
 
     assert (
-        "description" not in model_config_data_torch
-    ), "Should not have description in model config file"
+        "description" in model_config_data_torch
+        and model_config_data_torch["description"]
+        == "This is a sentence-transformers model: It maps sentences & paragraphs to a 384 dimensional dense vector space."
+    ), "Should use default model description when description is missing from README.md"
 
     clean_test_folder(TEST_FOLDER)
 


### PR DESCRIPTION
### Description
Enable make_model_config_json function to add description field to model config file

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
