### PR TITLE
Fixing typo in the model_search endpoint.

### DIFF
--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -426,10 +426,10 @@ class MLCommonClient:
 
     def search_model(self, input_json) -> object:
         """
-        This method searches a task from opensearch cluster (using ml commons api)
+        This method searches a model from opensearch cluster (using ml commons api)
         :param json: json input for the search request
         :type json: string or dict
-        :return: returns a json object, with detailed information about the searched task
+        :return: returns a json object, with detailed information about the searched model
         :rtype: object
         """
 


### PR DESCRIPTION
### Description
Fixes documentation error on `model_search` that says it takes in task id rather than a model ID. 
 
### Issues Resolved
N/A
 
### Check List
- [N/A] New functionality includes testing.
  - [N/A] All tests pass
- [N/A] New functionality has been documented.
  - [N/A] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
