### PR TITLE
Change to Use tokenCredentialId for Triggering ml-models-release via Generic Webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Enable make_model_config_json to add model description to model config file by @thanawan-atc in ([#203](https://github.com/opensearch-project/opensearch-py-ml/pull/203))
 - Correct demo_ml_commons_integration.ipynb by @thanawan-atc in ([#208](https://github.com/opensearch-project/opensearch-py-ml/pull/208))
 - Handle the case when the model max length is undefined in tokenizer by @thanawan-atc in ([#219](https://github.com/opensearch-project/opensearch-py-ml/pull/219))
+- Change to use tokenCredentialId for triggering ml-models-release via generic webhook by @thanawan-atc in ([#240](https://github.com/opensearch-project/opensearch-py-ml/pull/240))
 
 
 ## [1.1.0]

--- a/jenkins/ml-models.JenkinsFile
+++ b/jenkins/ml-models.JenkinsFile
@@ -41,7 +41,7 @@ pipeline {
                 [key: 'VERSION', value: '$.VERSION'],
                 [key: 'FORMAT', value: '$.FORMAT']
             ],
-            token: 'JENKINS_ML_MODELS_RELEASE_GENERIC_WEBHOOK_TOKEN',
+            tokenCredentialId: 'jenkins-ml-models-webhook-token',
             causeString: 'Triggered by GitHub Actions Workflow',
             printContributedVariables: true,
             printPostContent: true


### PR DESCRIPTION
### Description
Change to Use tokenCredentialId for Triggering ml-models-release via Generic Webhook

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
