### PR TITLE
New file for new model listing format

### DIFF
--- a/.github/workflows/model_listing_uploader.yml
+++ b/.github/workflows/model_listing_uploader.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     environment: opensearch-py-ml-cicd-env
     env:
-      bucket_model_listing_file_path: ml-models/model_listing/pre_trained_models.json
+      bucket_model_listing_file_path: ml-models/model_listing/pretrained_model_listing.json
       repo_model_listing_path: ./utils/model_uploader/model_listing/pretrained_model_listing.json
     steps:
     - name: Fail if branch is not main
@@ -31,7 +31,7 @@ jobs:
         aws-region: ${{ secrets.MODEL_UPLOADER_AWS_REGION }}
         role-to-assume: ${{ secrets.MODEL_UPLOADER_ROLE }}
         role-session-name: upload-model-listing
-    - name: Update pre_trained_models.json in S3
+    - name: Update pretrained_model_listing.json in S3
       run: aws s3 cp ${{ env.repo_model_listing_path }} s3://${{ secrets.MODEL_BUCKET }}/${{ env.bucket_model_listing_file_path }}
 
   trigger-ml-models-release-workflow:

--- a/.github/workflows/update_model_listing.yml
+++ b/.github/workflows/update_model_listing.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
-    - name: Update pre_trained_models.json
+    - name: Update pretrained_model_listing.json
       run: |
         python utils/model_uploader/update_pretrained_model_listing.py "config_paths.txt" "config_folder"
     - name: Create PR Body

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Modify ml-models.JenkinsFile so that it takes model format into account and can be triggered with generic webhook by @thanawan-atc in ([#211](https://github.com/opensearch-project/opensearch-py-ml/pull/211))
 - Update demo_tracing_model_torchscript_onnx.ipynb to use make_model_config_json by @thanawan-atc in ([#220](https://github.com/opensearch-project/opensearch-py-ml/pull/220))
-- Bump torch from 1.13.1 to 2.0.1 and add onnx dependency by  @thanawan-atc ([#237](https://github.com/opensearch-project/opensearch-py-ml/pull/237))
+- Bump torch from 1.13.1 to 2.0.1 and add onnx dependency by @thanawan-atc ([#237](https://github.com/opensearch-project/opensearch-py-ml/pull/237))
 - Update pretrained_model_listing.json (2023-08-23 16:51:21) by @dhrubo-os ([#248](https://github.com/opensearch-project/opensearch-py-ml/pull/248))
+- Store new format of model listing at pretrained_model_listing.json instead of pre_trained_models.json in S3 by @thanawan-atc ([#253](https://github.com/opensearch-project/opensearch-py-ml/pull/253))
 
 ### Fixed
 - Enable make_model_config_json to add model description to model config file by @thanawan-atc in ([#203](https://github.com/opensearch-project/opensearch-py-ml/pull/203))


### PR DESCRIPTION
### Description
Store new format of model listing at `pretrained_model_listing.json` instead of `pre_trained_models.json` in S3
 
### Issues Resolved
Since AOS 2.9 relies on the old format of model listing, we have to create a new file for new format to avoid issues.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
