### PR TITLE
Force model tracing workflow to fail early for ≥2GB Model

### DIFF
--- a/.github/workflows/model_uploader.yml
+++ b/.github/workflows/model_uploader.yml
@@ -175,10 +175,10 @@ jobs:
         run: "./.ci/run-tests ${{ matrix.cluster }} ${{ matrix.secured }} ${{ matrix.entry.opensearch_version }} trace"
       - name: Limit Model Size to 2GB
         run: |
-          upload_size=$(ls -lR ./upload/ | awk '{ SUM += $5} END {print SUM}')
-          limit="2147483648" 
-          echo "Model Artifact Size: $upload_size"
-          if [ "$upload_size" -ge "$limit" ]
+          upload_size_in_binary_bytes=$(ls -lR ./upload/ | awk '{ SUM += $5} END {print SUM}')
+          size_limit_in_binary_bytes="2147483648" 
+          echo "Model Artifact Size: $upload_size binary bytes"
+          if [ "$upload_size_in_binary_bytes" -ge "$size_limit_in_binary_bytes" ]
           then
             echo "The workflow cannot upload the model artifact that is larger than 2GB."
             exit 1

--- a/.github/workflows/model_uploader.yml
+++ b/.github/workflows/model_uploader.yml
@@ -177,7 +177,7 @@ jobs:
         run: |
           upload_size_in_binary_bytes=$(ls -lR ./upload/ | awk '{ SUM += $5} END {print SUM}')
           size_limit_in_binary_bytes="2147483648" 
-          echo "Model Artifact Size: $upload_size binary bytes"
+          echo "Model Artifact Size: $upload_size_in_binary_bytes binary bytes"
           if [ "$upload_size_in_binary_bytes" -ge "$size_limit_in_binary_bytes" ]
           then
             echo "The workflow cannot upload the model artifact that is larger than 2GB."

--- a/.github/workflows/model_uploader.yml
+++ b/.github/workflows/model_uploader.yml
@@ -173,6 +173,16 @@ jobs:
           echo "MODEL_DESCRIPTION=${{ github.event.inputs.model_description }}" >> $GITHUB_ENV     
       - name: Autotracing ${{ matrix.cluster }} secured=${{ matrix.secured }} version=${{matrix.entry.opensearch_version}}
         run: "./.ci/run-tests ${{ matrix.cluster }} ${{ matrix.secured }} ${{ matrix.entry.opensearch_version }} trace"
+      - name: Limit Model Size to 2GB
+        run: |
+          upload_size=$(ls -lR ./upload/ | awk '{ SUM += $5} END {print SUM}')
+          limit="2147483648" 
+          echo "Model Artifact Size: $upload_size"
+          if [ "$upload_size" -ge "$limit" ]
+          then
+            echo "The workflow cannot upload the model artifact that is larger than 2GB."
+            exit 1
+          fi
       - name: License Verification
         id: license_verification
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump torch from 1.13.1 to 2.0.1 and add onnx dependency by  @thanawan-atc ([#237](https://github.com/opensearch-project/opensearch-py-ml/pull/237))
 - Update pretrained_model_listing.json (2023-08-23 16:51:21) by @dhrubo-os ([#248](https://github.com/opensearch-project/opensearch-py-ml/pull/248))
 - Store new format of model listing at pretrained_models_all_versions.json instead of pre_trained_models.json in S3 and pretrained_model_listing.json in repo by @thanawan-atc ([#256](https://github.com/opensearch-project/opensearch-py-ml/pull/256))
+- Make the model tracing-uploading-releasing workflow fail early for ≥2GB model by @thanawan-atc ([#258](https://github.com/opensearch-project/opensearch-py-ml/pull/258))
 
 ### Fixed
 - Enable make_model_config_json to add model description to model config file by @thanawan-atc in ([#203](https://github.com/opensearch-project/opensearch-py-ml/pull/203))


### PR DESCRIPTION
### Description
Force model tracing workflow to fail early for ≥2GB Model
 
### Issues Resolved
Rather than having the workflow failed in the last step (Jenkins workflow), it is better to have it failed early to avoid discrepancy between our team's bucket and release bucket.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
