### PR TITLE
Rename model/model-listing workflows

### DIFF
--- a/.github/workflows/model_listing_uploader.yml
+++ b/.github/workflows/model_listing_uploader.yml
@@ -1,4 +1,4 @@
-name: Model Listing Uploading
+name: "Model Listing Workflow II: Uploading-Releasing [Auto-triggered]"
 on:
   push:
     branches:

--- a/.github/workflows/model_listing_uploader.yml
+++ b/.github/workflows/model_listing_uploader.yml
@@ -5,7 +5,6 @@ on:
      - main
     paths: 
      - utils/model_uploader/model_listing/pretrained_models_all_versions.json
-  workflow_dispatch:
   
 jobs:
   upload-model-listing:

--- a/.github/workflows/model_uploader.yml
+++ b/.github/workflows/model_uploader.yml
@@ -1,4 +1,4 @@
-name: Model Auto-tracing & Uploading
+name: "Model Upload Workflow: Tracing-Uploading-Releasing"
 on:
   # Step 1: Initiate the workflow
   workflow_dispatch:

--- a/.github/workflows/update_model_listing.yml
+++ b/.github/workflows/update_model_listing.yml
@@ -1,4 +1,4 @@
-name: Update Pretrained Model Listing
+name: "Model Listing Workflow I: Updating"
 on:
   workflow_dispatch:
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Modify ml-models.JenkinsFile so that it takes model format into account and can be triggered with generic webhook by @thanawan-atc in ([#211](https://github.com/opensearch-project/opensearch-py-ml/pull/211))
 - Update demo_tracing_model_torchscript_onnx.ipynb to use make_model_config_json by @thanawan-atc in ([#220](https://github.com/opensearch-project/opensearch-py-ml/pull/220))
-- Bump torch from 1.13.1 to 2.0.1 and add onnx dependency by  @thanawan-atc ([#237](https://github.com/opensearch-project/opensearch-py-ml/pull/237))
+- Bump torch from 1.13.1 to 2.0.1 and add onnx dependency by @thanawan-atc ([#237](https://github.com/opensearch-project/opensearch-py-ml/pull/237))
 - Update pretrained_model_listing.json (2023-08-23 16:51:21) by @dhrubo-os ([#248](https://github.com/opensearch-project/opensearch-py-ml/pull/248))
 - Store new format of model listing at pretrained_models_all_versions.json instead of pre_trained_models.json in S3 and pretrained_model_listing.json in repo by @thanawan-atc ([#256](https://github.com/opensearch-project/opensearch-py-ml/pull/256))
+- Rename model/model-listing workflows by @thanawan-atc ([#260](https://github.com/opensearch-project/opensearch-py-ml/pull/260))
 
 ### Fixed
 - Enable make_model_config_json to add model description to model config file by @thanawan-atc in ([#203](https://github.com/opensearch-project/opensearch-py-ml/pull/203))


### PR DESCRIPTION
### Description
- Rename model/model-listing workflows 
- Remove workflow_dispatch from "Model Listing Workflow II: Uploading-Releasing [Auto-triggered]" -> Allow it to be triggered upon file change only
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
