### PR TITLE
Fix conditional job execution issue in model upload workflow

### DIFF
--- a/.github/workflows/model_uploader.yml
+++ b/.github/workflows/model_uploader.yml
@@ -56,11 +56,11 @@ jobs:
   init-workflow-var:
     runs-on: 'ubuntu-latest'
     steps:
-    # - name: Fail if branch is not main
-    #   if: github.ref != 'refs/heads/main'
-    #   run: |
-    #      echo "This workflow should only be triggered on 'main' branch"
-    #      exit 1
+    - name: Fail if branch is not main
+      if: github.ref != 'refs/heads/main'
+      run: |
+         echo "This workflow should only be triggered on 'main' branch"
+         exit 1
     - name: Initiate folders
       id: init_folders
       run: |
@@ -123,12 +123,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      # - name: Configure AWS Credentials
-      #   uses: aws-actions/configure-aws-credentials@v2
-      #   with:
-      #     aws-region: ${{ secrets.MODEL_UPLOADER_AWS_REGION }}
-      #     role-to-assume: ${{ secrets.MODEL_UPLOADER_ROLE }}
-      #     role-session-name: checking-out-model-hub
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ secrets.MODEL_UPLOADER_AWS_REGION }}
+          role-to-assume: ${{ secrets.MODEL_UPLOADER_ROLE }}
+          role-session-name: checking-out-model-hub
       - name: Check if TORCH_SCRIPT Model Exists
         if: github.event.inputs.allow_overwrite == 'NO' && (github.event.inputs.tracing_format == 'TORCH_SCRIPT' || github.event.inputs.tracing_format == 'BOTH')
         run: |
@@ -217,22 +217,22 @@ jobs:
           path: ./upload/
           retention-days: 5
           if-no-files-found: error
-      # - name: Configure AWS Credentials
-      #   uses: aws-actions/configure-aws-credentials@v2
-      #   with:
-      #     aws-region: ${{ secrets.MODEL_UPLOADER_AWS_REGION }}
-      #     role-to-assume: ${{ secrets.MODEL_UPLOADER_ROLE }}
-      #     role-session-name: model-auto-tracing
-      # - name: Dryrun model uploading
-      #   id: dryrun_model_uploading
-      #   run: |
-      #     dryrun_output=$(aws s3 sync ./upload/ s3://${{ secrets.MODEL_BUCKET }}/${{ needs.init-workflow-var.outputs.sentence_transformer_folder }} --dryrun \
-      #       | sed 's|s3://${{ secrets.MODEL_BUCKET }}/|s3://(MODEL_BUCKET)/|' 
-      #     )
-      #     echo "dryrun_output<<EOF" >> $GITHUB_OUTPUT
-      #     echo "${dryrun_output@E}" >> $GITHUB_OUTPUT
-      #     echo "EOF" >> $GITHUB_OUTPUT
-      #     echo "${dryrun_output@E}"
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ secrets.MODEL_UPLOADER_AWS_REGION }}
+          role-to-assume: ${{ secrets.MODEL_UPLOADER_ROLE }}
+          role-session-name: model-auto-tracing
+      - name: Dryrun model uploading
+        id: dryrun_model_uploading
+        run: |
+          dryrun_output=$(aws s3 sync ./upload/ s3://${{ secrets.MODEL_BUCKET }}/${{ needs.init-workflow-var.outputs.sentence_transformer_folder }} --dryrun \
+            | sed 's|s3://${{ secrets.MODEL_BUCKET }}/|s3://(MODEL_BUCKET)/|' 
+          )
+          echo "dryrun_output<<EOF" >> $GITHUB_OUTPUT
+          echo "${dryrun_output@E}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "${dryrun_output@E}"
     outputs:
       license_line: ${{ steps.license_verification.outputs.license_line }}
       license_info: ${{ steps.license_verification.outputs.license_info }}

--- a/.github/workflows/model_uploader.yml
+++ b/.github/workflows/model_uploader.yml
@@ -123,12 +123,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-region: ${{ secrets.MODEL_UPLOADER_AWS_REGION }}
-          role-to-assume: ${{ secrets.MODEL_UPLOADER_ROLE }}
-          role-session-name: checking-out-model-hub
+      # - name: Configure AWS Credentials
+      #   uses: aws-actions/configure-aws-credentials@v2
+      #   with:
+      #     aws-region: ${{ secrets.MODEL_UPLOADER_AWS_REGION }}
+      #     role-to-assume: ${{ secrets.MODEL_UPLOADER_ROLE }}
+      #     role-session-name: checking-out-model-hub
       - name: Check if TORCH_SCRIPT Model Exists
         if: github.event.inputs.allow_overwrite == 'NO' && (github.event.inputs.tracing_format == 'TORCH_SCRIPT' || github.event.inputs.tracing_format == 'BOTH')
         run: |

--- a/.github/workflows/model_uploader.yml
+++ b/.github/workflows/model_uploader.yml
@@ -56,11 +56,11 @@ jobs:
   init-workflow-var:
     runs-on: 'ubuntu-latest'
     steps:
-    - name: Fail if branch is not main
-      if: github.ref != 'refs/heads/main'
-      run: |
-         echo "This workflow should only be triggered on 'main' branch"
-         exit 1
+    # - name: Fail if branch is not main
+    #   if: github.ref != 'refs/heads/main'
+    #   run: |
+    #      echo "This workflow should only be triggered on 'main' branch"
+    #      exit 1
     - name: Initiate folders
       id: init_folders
       run: |
@@ -111,7 +111,6 @@ jobs:
   # Step 3: Check if the model already exists in the model hub
   checking-out-model-hub:
     needs: init-workflow-var
-    if: github.event.inputs.allow_overwrite == 'NO'
     runs-on: 'ubuntu-latest'
     permissions:
       id-token: write
@@ -131,7 +130,7 @@ jobs:
           role-to-assume: ${{ secrets.MODEL_UPLOADER_ROLE }}
           role-session-name: checking-out-model-hub
       - name: Check if TORCH_SCRIPT Model Exists
-        if: github.event.inputs.tracing_format == 'TORCH_SCRIPT' || github.event.inputs.tracing_format == 'BOTH'
+        if: github.event.inputs.allow_overwrite == 'NO' && (github.event.inputs.tracing_format == 'TORCH_SCRIPT' || github.event.inputs.tracing_format == 'BOTH')
         run: |
           TORCH_FILE_PATH=$(python utils/model_uploader/save_model_file_path_to_env.py \
               ${{ needs.init-workflow-var.outputs.sentence_transformer_folder }} ${{ github.event.inputs.model_id }} \
@@ -143,7 +142,7 @@ jobs:
             exit 1
           fi
       - name: Check if ONNX Model Exists
-        if: github.event.inputs.tracing_format == 'ONNX' || github.event.inputs.tracing_format == 'BOTH'
+        if: github.event.inputs.allow_overwrite == 'NO' && (github.event.inputs.tracing_format == 'ONNX' || github.event.inputs.tracing_format == 'BOTH')
         run: |
           ONNX_FILE_PATH=$(python utils/model_uploader/save_model_file_path_to_env.py \
             ${{ needs.init-workflow-var.outputs.sentence_transformer_folder }} ${{ github.event.inputs.model_id }} \
@@ -158,7 +157,6 @@ jobs:
   # Step 4: Trace the model, Verify the embeddings & Upload the model files as artifacts
   model-auto-tracing:
     needs: [init-workflow-var, checking-out-model-hub]
-    if:  always() && needs.init-workflow-var.result == 'success' && (needs.checking-out-model-hub.result == 'success' || needs.checking-out-model-hub.result == 'skipped')
     name: model-auto-tracing
     runs-on: ubuntu-latest
     permissions:
@@ -219,22 +217,22 @@ jobs:
           path: ./upload/
           retention-days: 5
           if-no-files-found: error
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-region: ${{ secrets.MODEL_UPLOADER_AWS_REGION }}
-          role-to-assume: ${{ secrets.MODEL_UPLOADER_ROLE }}
-          role-session-name: model-auto-tracing
-      - name: Dryrun model uploading
-        id: dryrun_model_uploading
-        run: |
-          dryrun_output=$(aws s3 sync ./upload/ s3://${{ secrets.MODEL_BUCKET }}/${{ needs.init-workflow-var.outputs.sentence_transformer_folder }} --dryrun \
-            | sed 's|s3://${{ secrets.MODEL_BUCKET }}/|s3://(MODEL_BUCKET)/|' 
-          )
-          echo "dryrun_output<<EOF" >> $GITHUB_OUTPUT
-          echo "${dryrun_output@E}" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          echo "${dryrun_output@E}"
+      # - name: Configure AWS Credentials
+      #   uses: aws-actions/configure-aws-credentials@v2
+      #   with:
+      #     aws-region: ${{ secrets.MODEL_UPLOADER_AWS_REGION }}
+      #     role-to-assume: ${{ secrets.MODEL_UPLOADER_ROLE }}
+      #     role-session-name: model-auto-tracing
+      # - name: Dryrun model uploading
+      #   id: dryrun_model_uploading
+      #   run: |
+      #     dryrun_output=$(aws s3 sync ./upload/ s3://${{ secrets.MODEL_BUCKET }}/${{ needs.init-workflow-var.outputs.sentence_transformer_folder }} --dryrun \
+      #       | sed 's|s3://${{ secrets.MODEL_BUCKET }}/|s3://(MODEL_BUCKET)/|' 
+      #     )
+      #     echo "dryrun_output<<EOF" >> $GITHUB_OUTPUT
+      #     echo "${dryrun_output@E}" >> $GITHUB_OUTPUT
+      #     echo "EOF" >> $GITHUB_OUTPUT
+      #     echo "${dryrun_output@E}"
     outputs:
       license_line: ${{ steps.license_verification.outputs.license_line }}
       license_info: ${{ steps.license_verification.outputs.license_info }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update pretrained_models_all_versions.json (2023-09-08 13:14:07) by @dhrubo-os ([#277](https://github.com/opensearch-project/opensearch-py-ml/pull/277))
 - Update model upload history -  sentence-transformers/distiluse-base-multilingual-cased-v1 (v.1.0.1)(TORCH_SCRIPT) by @dhrubo-os ([#281](https://github.com/opensearch-project/opensearch-py-ml/pull/281))
 - Update pretrained_models_all_versions.json (2023-09-14 10:28:41) by @dhrubo-os ([#282](https://github.com/opensearch-project/opensearch-py-ml/pull/282))
-Enable the model upload workflow to add model_content_size_in_bytes & model_content_hash_value to model config automatically @thanawan-atc ([#291](https://github.com/opensearch-project/opensearch-py-ml/pull/291))
+- Enable the model upload workflow to add model_content_size_in_bytes & model_content_hash_value to model config automatically @thanawan-atc ([#291](https://github.com/opensearch-project/opensearch-py-ml/pull/291))
 
 ### Fixed
 - Enable make_model_config_json to add model description to model config file by @thanawan-atc in ([#203](https://github.com/opensearch-project/opensearch-py-ml/pull/203))
@@ -35,6 +35,7 @@ Enable the model upload workflow to add model_content_size_in_bytes & model_cont
 - Add BUCKET_NAME to ml-models-release jenkinsfile by @thanawan-atc in ([#249](https://github.com/opensearch-project/opensearch-py-ml/pull/249))
 - Roll over pretrained_model_listing.json because of ml-commons dependency by @thanawan-atc in ([#252](https://github.com/opensearch-project/opensearch-py-ml/pull/252))
 - Fix pandas dependency issue in nox session by installing pandas package to python directly by @thanawan-atc in ([#266](https://github.com/opensearch-project/opensearch-py-ml/pull/266))
+- Fix conditional job execution issue in model upload workflow by @thanawan-atc in ([#294](https://github.com/opensearch-project/opensearch-py-ml/pull/294))
 
 ## [1.1.0]
 


### PR DESCRIPTION
### Description
Fix conditional job execution issue in model upload workflow by skipping two steps in a job instead of skipping the job

<img width="299" alt="Screen Shot 2566-09-18 at 22 13 14" src="https://github.com/opensearch-project/opensearch-py-ml/assets/106889996/6770fa22-6e7d-4536-8e33-fc8051f5774a">

### Issues Resolved
Given that we have three jobs A -> B -> C -> D. If job A is skipped, even though we can make job B succeed by adding `if: always() && (needs.A.result == 'success' || needs.A.result == 'skipped')`. It is not enough. All the jobs that "indirectly" depend on A will fail because A is skipped. 
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
