### PR TITLE
[OSCI] fixed formatting of install header in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ clusters using the [ml-commons](https://github.com/opensearch-project/ml-commons
 For more information, see [opensearch.org](https://opensearch.org/docs/latest/clients/opensearch-py-ml/) and the [API Doc](https://opensearch-project.github.io/opensearch-py-ml/index.html).
 
 
-##Installing Opensearch-py-ml
+## Installing Opensearch-py-ml
 
 
 Opensearch-py-ml can be installed from [PyPI](https://pypi.org/project/opensearch-py-ml) via pip:


### PR DESCRIPTION
### Fixed formatting for "Installing Opensearch-py-ml" header
The README originally had the ## visible in the header so, the header wasn't functioning as a header, so I added a space between the ## and installing to make it a header. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
