### PR TITLE
[OSCI] Add ML-Commons Train and Predict api functionality in py-ml

### DIFF
--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -361,14 +361,14 @@ class MLCommonClient:
 
     def train_and_predict(self, algorithm_name: str, input_json):
         """
-        This method trains a model with dataset and makes a prediction with the same dataset 
+        This method trains a model with dataset and makes a prediction with the same dataset
         using ml commons train and predict api
 
         :param algorithm_name: name of algorithm used to train model ("BATCH_RCF", "FIT_RCF", or "kmeans")
         :type algorithm_name: str
         :param input_json: json input for train and predict dataset
         :type input_json: str or dict
-        
+
         :return: returns a json object with task status and prediction results
         :rtype: object
         """
@@ -391,13 +391,11 @@ class MLCommonClient:
         else:
             return "Invalid JSON object passed as argument."
 
-
-        res = self._client.transport.perform_request(
-            method="POST", 
-            url=API_URL, 
-            body=API_BODY, 
+        return self._client.transport.perform_request(
+            method="POST",
+            url=API_URL,
+            body=API_BODY,
         )
-
 
     def get_task_info(self, task_id: str, wait_until_task_done: bool = False) -> object:
         """
@@ -425,7 +423,6 @@ class MLCommonClient:
                 ):
                     task_flag = True
         return self._get_task_info(task_id)
-
 
     def _get_task_info(self, task_id: str):
         API_URL = f"{ML_BASE_URI}/tasks/{task_id}"

--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -375,7 +375,7 @@ class MLCommonClient:
         API_URL = f"{ML_BASE_URI}/_train_predict/{algorithm_name}"
         API_BODY = ""
 
-        if algorithm_name in ["BATCH_RCF", "FIT_RCF", "kmeans"]:
+        if not algorithm_name in ["BATCH_RCF", "FIT_RCF", "kmeans"]:
             return "Invalid algorithm name passed as argument."
 
         if isinstance(input_json, str):

--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -359,6 +359,43 @@ class MLCommonClient:
 
         return self._get_task_info(task_id)
 
+    def train_and_predict(self, algorithm_name: str, input_json):
+        """
+        This method trains a model with dataset and makes a prediction with the same dataset 
+        using ml commons train and predict api
+
+        :param algorithm_name: name of algorithm used to train model ("BATCH_RCF", "FIT_RCF", or "kmeans")
+        :type algorithm_name: str
+        :param input_json: json input for train and predict dataset
+        :type input_json: str or dict
+        
+        :return: returns a json object with task status and prediction results
+        :rtype: object
+        """
+        API_URL = f"{ML_BASE_URI}/_train_predict/{algorithm_name}"
+        API_BODY = ""
+
+        if isinstance(input_json, str):
+            try:
+                json_obj = json.loads(input_json)
+                if not isinstance(json_obj, dict):
+                    return "Invalid JSON object passed as argument."
+                API_BODY = json.dumps(json_obj)
+            except json.JSONDecodeError:
+                return "Invalid JSON string passed as argument."
+        elif isinstance(input_json, dict):
+            API_BODY = json.dumps(input_json)
+        else:
+            return "Invalid JSON object passed as argument."
+
+
+        res = self._client.transport.perform_request(
+            method="POST", 
+            url=API_URL, 
+            body=API_BODY, 
+        )
+
+
     def get_task_info(self, task_id: str, wait_until_task_done: bool = False) -> object:
         """
         This method return information about a task running into opensearch cluster (using ml commons api)
@@ -385,6 +422,7 @@ class MLCommonClient:
                 ):
                     task_flag = True
         return self._get_task_info(task_id)
+
 
     def _get_task_info(self, task_id: str):
         API_URL = f"{ML_BASE_URI}/tasks/{task_id}"

--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -375,7 +375,7 @@ class MLCommonClient:
         API_URL = f"{ML_BASE_URI}/_train_predict/{algorithm_name}"
         API_BODY = ""
 
-        if not algorithm_name in ["BATCH_RCF", "FIT_RCF", "kmeans"]:
+        if algorithm_name not in ["BATCH_RCF", "FIT_RCF", "kmeans"]:
             return "Invalid algorithm name passed as argument."
 
         if isinstance(input_json, str):

--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -375,6 +375,9 @@ class MLCommonClient:
         API_URL = f"{ML_BASE_URI}/_train_predict/{algorithm_name}"
         API_BODY = ""
 
+        if algorithm_name in ["BATCH_RCF", "FIT_RCF", "kmeans"]:
+            return "Invalid algorithm name passed as argument."
+
         if isinstance(input_json, str):
             try:
                 json_obj = json.loads(input_json)

--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -346,6 +346,118 @@ class MLCommonClient:
 
         return self._get_task_info(task_id)
 
+    def test_train_and_predict():
+        input_json = {
+            "parameters": {"centroids": 2, "iterations": 1, "distance_type": "EUCLIDEAN"},
+            "input_data": {
+                "column_metas": [
+                    {"name": "k1", "column_type": "DOUBLE"},
+                    {"name": "k2", "column_type": "DOUBLE"},
+                ],
+                "rows": [
+                    {
+                        "values": [
+                            {"column_type": "DOUBLE", "value": 1.00},
+                            {"column_type": "DOUBLE", "value": 2.00},
+                        ]
+                    },
+                    {
+                        "values": [
+                            {"column_type": "DOUBLE", "value": 1.00},
+                            {"column_type": "DOUBLE", "value": 4.00},
+                        ]
+                    },
+                    {
+                        "values": [
+                            {"column_type": "DOUBLE", "value": 1.00},
+                            {"column_type": "DOUBLE", "value": 0.00},
+                        ]
+                    },
+                    {
+                        "values": [
+                            {"column_type": "DOUBLE", "value": 10.00},
+                            {"column_type": "DOUBLE", "value": 2.00},
+                        ]
+                    },
+                    {
+                        "values": [
+                            {"column_type": "DOUBLE", "value": 10.00},
+                            {"column_type": "DOUBLE", "value": 4.00},
+                        ]
+                    },
+                    {
+                        "values": [
+                            {"column_type": "DOUBLE", "value": 10.00},
+                            {"column_type": "DOUBLE", "value": 0.00},
+                        ]
+                    },
+                ],
+            },
+        }
+
+        input_str = json.dumps(input_json)
+
+        raised = False
+        try:
+            train_and_predict_obj = ml_client.train_and_predict(
+                algorithm_name="kmeans", input_json=input_json
+            )
+            assert train_and_predict_obj["status"] == "COMPLETED"
+        except:  # noqa: E722
+            raised = True
+        assert raised == False, "Raised Exception in training and predicting task"
+
+        raised = False
+        try:
+            train_and_predict_obj = ml_client.train_and_predict(
+                algorithm_name="kmeans", input_json=input_str
+            )
+            assert train_and_predict_obj["status"] == "COMPLETED"
+        except:  # noqa: E722
+            raised = True
+        assert raised == False, "Raised Exception in training and predicting task"
+
+        raised = False
+        try:
+            train_and_predict_obj = ml_client.train_and_predict(
+                algorithm_name="not an alg", input_json=input_json
+            )
+            assert train_and_predict_obj == "Invalid algorithm name passed as argument."
+        except:  # noqa: E722
+            raised = True
+        assert raised == False, "Raised Exception in training and predicting task"
+
+        raised = False
+        try:
+            train_and_predict_obj = ml_client.train_and_predict(
+                algorithm_name="kmeans", input_json=input_str + " invalid json"
+            )
+            assert train_and_predict_obj == "Invalid JSON string passed as argument."
+        except:  # noqa: E722
+            raised = True
+        assert raised == False, "Raised Exception in training and predicting task"
+
+        raised = False
+        try:
+            train_and_predict_obj = ml_client.train_and_predict(
+                algorithm_name="kmeans", input_json="15"
+            )
+            assert train_and_predict_obj == "Invalid JSON object passed as argument."
+        except:  # noqa: E722
+            raised = True
+        assert raised == False, "Raised Exception in training and predicting task"
+
+        raised = False
+        try:
+            train_and_predict_obj = ml_client.train_and_predict(
+                algorithm_name="kmeans", input_json=15
+            )
+            assert train_and_predict_obj == "Invalid JSON object passed as argument."
+        except:  # noqa: E722
+            raised = True
+        assert raised == False, "Raised Exception in training and predicting task"
+
+
     def deploy_model(self, model_id: str, wait_until_deployed: bool = True) -> object:
         """
         This method deploys a model in the opensearch cluster using ml-common plugin's deploy model api

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -9,6 +9,8 @@ import os
 import shutil
 from os.path import exists
 
+import json
+
 from opensearchpy import OpenSearch
 
 from opensearch_py_ml.ml_commons import MLCommonClient
@@ -194,6 +196,169 @@ def test_search():
     except:  # noqa: E722
         raised = True
     assert raised == False, "Raised Exception in searching model"
+
+def test_train_and_predict():
+    input_json = {
+        "parameters": {
+            "centroids": 2,
+            "iterations": 1,
+            "distance_type": "EUCLIDEAN"
+        },
+        "input_data": {
+            "column_metas": [
+                {
+                    "name": "k1",
+                    "column_type": "DOUBLE"
+                },
+                {
+                    "name": "k2",
+                    "column_type": "DOUBLE"
+                }
+            ],
+            "rows": [
+                {
+                    "values": [
+                        {
+                            "column_type": "DOUBLE",
+                            "value": 1.00
+                        },
+                        {
+                            "column_type": "DOUBLE",
+                            "value": 2.00
+                        }
+                    ]
+                },
+                {
+                    "values": [
+                        {
+                            "column_type": "DOUBLE",
+                            "value": 1.00
+                        },
+                        {
+                            "column_type": "DOUBLE",
+                            "value": 4.00
+                        }
+                    ]
+                },
+                {
+                    "values": [
+                        {
+                            "column_type": "DOUBLE",
+                            "value": 1.00
+                        },
+                        {
+                            "column_type": "DOUBLE",
+                            "value": 0.00
+                        }
+                    ]
+                },
+                {
+                    "values": [
+                        {
+                            "column_type": "DOUBLE",
+                            "value": 10.00
+                        },
+                        {
+                            "column_type": "DOUBLE",
+                            "value": 2.00
+                        }
+                    ]
+                },
+                {
+                    "values": [
+                        {
+                            "column_type": "DOUBLE",
+                            "value": 10.00
+                        },
+                        {
+                            "column_type": "DOUBLE",
+                            "value": 4.00
+                        }
+                    ]
+                },
+                {
+                    "values": [
+                        {
+                            "column_type": "DOUBLE",
+                            "value": 10.00
+                        },
+                        {
+                            "column_type": "DOUBLE",
+                            "value": 0.00
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+
+    input_str = json.dumps(input_json)
+
+    raised = False
+    try:
+        train_and_predict_obj = ml_client.train_and_predict(
+            algorithm_name="kmeans",
+            input_json=input_json
+        )
+        assert (train_and_predict_obj["status"] == "Completed" and isinstance(train_and_predict_obj["prediction_result"], dict))
+    except:
+        raised = True
+    assert raised == False, "Raised Exception in training and predicting task"
+
+    raised = False
+    try:
+        train_and_predict_obj = ml_client.train_and_predict(
+            algorithm_name="kmeans",
+            input_json=input_str
+        )
+        assert (train_and_predict_obj["status"] == "Completed" and isinstance(train_and_predict_obj["prediction_result"], dict))
+    except:
+        raised = True
+    assert raised == False, "Raised Exception in training and predicting task"
+
+    raised = False
+    try:
+        train_and_predict_obj = ml_client.train_and_predict(
+            algorithm_name="not an alg",
+            input_json=input_json
+        )
+        assert train_and_predict_obj == "Invalid algorithm name passed as argument."
+    except:
+        raised = True
+    assert raised == False, "Raised Exception in training and predicting task"
+
+    raised = False
+    try:
+        train_and_predict_obj = ml_client.train_and_predict(
+            algorithm_name="kmeans",
+            input_json=input_str + " invalid json"
+        )
+        assert train_and_predict_obj == "Invalid JSON string passed as argument."
+    except:
+        raised = True
+    assert raised == False, "Raised Exception in training and predicting task"
+
+    raised = False
+    try:
+        train_and_predict_obj = ml_client.train_and_predict(
+            algorithm_name="kmeans",
+            input_json="15"
+        )
+        assert train_and_predict_obj == "Invalid JSON object passed as argument."
+    except:
+        raised = True
+    assert raised == False, "Raised Exception in training and predicting task"
+
+    raised = False
+    try:
+        train_and_predict_obj = ml_client.train_and_predict(
+            algorithm_name="kmeans",
+            input_json=15
+        )
+        assert train_and_predict_obj == "Invalid JSON object passed as argument."
+    except:
+        raised = True
+    assert raised == False, "Raised Exception in training and predicting task"
 
 
 def test_DEPRECATED_integration_pretrained_model_upload_unload_delete():

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -5,11 +5,10 @@
 # Any modifications Copyright OpenSearch Contributors. See
 # GitHub history for details.
 
+import json
 import os
 import shutil
 from os.path import exists
-
-import json
 
 from opensearchpy import OpenSearch
 
@@ -197,99 +196,54 @@ def test_search():
         raised = True
     assert raised == False, "Raised Exception in searching model"
 
+
 def test_train_and_predict():
     input_json = {
-        "parameters": {
-            "centroids": 2,
-            "iterations": 1,
-            "distance_type": "EUCLIDEAN"
-        },
+        "parameters": {"centroids": 2, "iterations": 1, "distance_type": "EUCLIDEAN"},
         "input_data": {
             "column_metas": [
-                {
-                    "name": "k1",
-                    "column_type": "DOUBLE"
-                },
-                {
-                    "name": "k2",
-                    "column_type": "DOUBLE"
-                }
+                {"name": "k1", "column_type": "DOUBLE"},
+                {"name": "k2", "column_type": "DOUBLE"},
             ],
             "rows": [
                 {
                     "values": [
-                        {
-                            "column_type": "DOUBLE",
-                            "value": 1.00
-                        },
-                        {
-                            "column_type": "DOUBLE",
-                            "value": 2.00
-                        }
+                        {"column_type": "DOUBLE", "value": 1.00},
+                        {"column_type": "DOUBLE", "value": 2.00},
                     ]
                 },
                 {
                     "values": [
-                        {
-                            "column_type": "DOUBLE",
-                            "value": 1.00
-                        },
-                        {
-                            "column_type": "DOUBLE",
-                            "value": 4.00
-                        }
+                        {"column_type": "DOUBLE", "value": 1.00},
+                        {"column_type": "DOUBLE", "value": 4.00},
                     ]
                 },
                 {
                     "values": [
-                        {
-                            "column_type": "DOUBLE",
-                            "value": 1.00
-                        },
-                        {
-                            "column_type": "DOUBLE",
-                            "value": 0.00
-                        }
+                        {"column_type": "DOUBLE", "value": 1.00},
+                        {"column_type": "DOUBLE", "value": 0.00},
                     ]
                 },
                 {
                     "values": [
-                        {
-                            "column_type": "DOUBLE",
-                            "value": 10.00
-                        },
-                        {
-                            "column_type": "DOUBLE",
-                            "value": 2.00
-                        }
+                        {"column_type": "DOUBLE", "value": 10.00},
+                        {"column_type": "DOUBLE", "value": 2.00},
                     ]
                 },
                 {
                     "values": [
-                        {
-                            "column_type": "DOUBLE",
-                            "value": 10.00
-                        },
-                        {
-                            "column_type": "DOUBLE",
-                            "value": 4.00
-                        }
+                        {"column_type": "DOUBLE", "value": 10.00},
+                        {"column_type": "DOUBLE", "value": 4.00},
                     ]
                 },
                 {
                     "values": [
-                        {
-                            "column_type": "DOUBLE",
-                            "value": 10.00
-                        },
-                        {
-                            "column_type": "DOUBLE",
-                            "value": 0.00
-                        }
+                        {"column_type": "DOUBLE", "value": 10.00},
+                        {"column_type": "DOUBLE", "value": 0.00},
                     ]
-                }
-            ]
-        }
+                },
+            ],
+        },
     }
 
     input_str = json.dumps(input_json)
@@ -297,66 +251,64 @@ def test_train_and_predict():
     raised = False
     try:
         train_and_predict_obj = ml_client.train_and_predict(
-            algorithm_name="kmeans",
-            input_json=input_json
+            algorithm_name="kmeans", input_json=input_json
         )
-        assert (train_and_predict_obj["status"] == "Completed" and isinstance(train_and_predict_obj["prediction_result"], dict))
-    except:
+        assert train_and_predict_obj["status"] == "Completed" and isinstance(
+            train_and_predict_obj["prediction_result"], dict
+        )
+    except:  # noqa: E722
         raised = True
     assert raised == False, "Raised Exception in training and predicting task"
 
     raised = False
     try:
         train_and_predict_obj = ml_client.train_and_predict(
-            algorithm_name="kmeans",
-            input_json=input_str
+            algorithm_name="kmeans", input_json=input_str
         )
-        assert (train_and_predict_obj["status"] == "Completed" and isinstance(train_and_predict_obj["prediction_result"], dict))
-    except:
+        assert train_and_predict_obj["status"] == "Completed" and isinstance(
+            train_and_predict_obj["prediction_result"], dict
+        )
+    except:  # noqa: E722
         raised = True
     assert raised == False, "Raised Exception in training and predicting task"
 
     raised = False
     try:
         train_and_predict_obj = ml_client.train_and_predict(
-            algorithm_name="not an alg",
-            input_json=input_json
+            algorithm_name="not an alg", input_json=input_json
         )
         assert train_and_predict_obj == "Invalid algorithm name passed as argument."
-    except:
+    except:  # noqa: E722
         raised = True
     assert raised == False, "Raised Exception in training and predicting task"
 
     raised = False
     try:
         train_and_predict_obj = ml_client.train_and_predict(
-            algorithm_name="kmeans",
-            input_json=input_str + " invalid json"
+            algorithm_name="kmeans", input_json=input_str + " invalid json"
         )
         assert train_and_predict_obj == "Invalid JSON string passed as argument."
-    except:
+    except:  # noqa: E722
         raised = True
     assert raised == False, "Raised Exception in training and predicting task"
 
     raised = False
     try:
         train_and_predict_obj = ml_client.train_and_predict(
-            algorithm_name="kmeans",
-            input_json="15"
+            algorithm_name="kmeans", input_json="15"
         )
         assert train_and_predict_obj == "Invalid JSON object passed as argument."
-    except:
+    except:  # noqa: E722
         raised = True
     assert raised == False, "Raised Exception in training and predicting task"
 
     raised = False
     try:
         train_and_predict_obj = ml_client.train_and_predict(
-            algorithm_name="kmeans",
-            input_json=15
+            algorithm_name="kmeans", input_json=15
         )
         assert train_and_predict_obj == "Invalid JSON object passed as argument."
-    except:
+    except:  # noqa: E722
         raised = True
     assert raised == False, "Raised Exception in training and predicting task"
 

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -5,7 +5,6 @@
 # Any modifications Copyright OpenSearch Contributors. See
 # GitHub history for details.
 
-import json
 import os
 import shutil
 import time

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -253,9 +253,7 @@ def test_train_and_predict():
         train_and_predict_obj = ml_client.train_and_predict(
             algorithm_name="kmeans", input_json=input_json
         )
-        assert train_and_predict_obj["status"] == "Completed" and isinstance(
-            train_and_predict_obj["prediction_result"], dict
-        )
+        assert train_and_predict_obj["status"] == "COMPLETED"
     except:  # noqa: E722
         raised = True
     assert raised == False, "Raised Exception in training and predicting task"
@@ -265,9 +263,7 @@ def test_train_and_predict():
         train_and_predict_obj = ml_client.train_and_predict(
             algorithm_name="kmeans", input_json=input_str
         )
-        assert train_and_predict_obj["status"] == "Completed" and isinstance(
-            train_and_predict_obj["prediction_result"], dict
-        )
+        assert train_and_predict_obj["status"] == "COMPLETED"
     except:  # noqa: E722
         raised = True
     assert raised == False, "Raised Exception in training and predicting task"


### PR DESCRIPTION
### Description
Added train and predict method and test cases for it in ml-commons-client.py that uses the ML Commons API to train a model and make a prediction using the given dataset. 
 
### Issues Resolved
Closes #288 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
