### PR TITLE
limit pandas version to 1.X

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 #
 # Basic requirements
 #
-pandas>=1.5.2,<3
+pandas>=1.5.2,<2
 matplotlib>=3.6.2,<4
 numpy>=1.24.0,<2
 opensearch-py>=2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 #
 # Basic requirements
 #
-pandas>=1.5.2,<3
+pandas>=1.5.2,<2
 matplotlib>=3.6.2,<4
 numpy>=1.24.0,<2
 opensearch-py>=2.2.0


### PR DESCRIPTION
### Description
Current pandas version pinned in main branch is failing when import `is_datetime_or_timedelta` . Hence, we can temporarily limit pandas version to 1.x till the fix the bug.
 
### Issues Resolved
#263  
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
