### PR TITLE
replace `is_datetime_or_timedelta_dtype`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add workflow and scripts for automating model listing updating process by @thanawan-atc in ([#210](https://github.com/opensearch-project/opensearch-py-ml/pull/210))
 - Add script to trigger ml-models-release jenkins workflow with generic webhook by @thanawan-atc in ([#211](https://github.com/opensearch-project/opensearch-py-ml/pull/211))
 - Add example notebook for tracing and registering a CLIPTextModel to OpenSearch with the Neural Search plugin by @patrickbarnhart in ([#283](https://github.com/opensearch-project/opensearch-py-ml/pull/283))
+- Replaced usage of `is_datetime_or_timedelta_dtype` with `is_timedelta64_dtype` and `is_datetime64_any_dtype`([#316](https://github.com/opensearch-project/opensearch-py-ml/pull/316))
 
 ### Changed
 - Modify ml-models.JenkinsFile so that it takes model format into account and can be triggered with generic webhook by @thanawan-atc in ([#211](https://github.com/opensearch-project/opensearch-py-ml/pull/211))

--- a/opensearch_py_ml/field_mappings.py
+++ b/opensearch_py_ml/field_mappings.py
@@ -43,7 +43,7 @@ import pandas as pd  # type: ignore
 from pandas.core.dtypes.common import is_bool_dtype  # type: ignore
 from pandas.core.dtypes.common import (
     is_datetime64_any_dtype,
-    is_datetime_or_timedelta_dtype,
+    is_timedelta64_dtype,
     is_float_dtype,
     is_integer_dtype,
     is_string_dtype,
@@ -91,7 +91,7 @@ class Field(NamedTuple):
 
     @property
     def is_timestamp(self) -> bool:
-        return is_datetime_or_timedelta_dtype(self.pd_dtype)
+        return is_datetime64_any_dtype(self.pd_dtype) or is_timedelta64_dtype(self.pd_dtype)
 
     @property
     def is_bool(self) -> bool:
@@ -509,7 +509,7 @@ class FieldMappings:
             os_dtype = "boolean"
         elif is_string_dtype(pd_dtype):
             os_dtype = "keyword"
-        elif is_datetime_or_timedelta_dtype(pd_dtype):
+        elif is_datetime64_any_dtype(pd_dtype) or is_timedelta64_dtype(pd_dtype):
             os_dtype = "date"
         elif is_datetime64_any_dtype(pd_dtype):
             os_dtype = "date"
@@ -794,7 +794,7 @@ class FieldMappings:
                 pd_dtypes.append(np.dtype(pd_dtype))
                 os_field_names.append(os_field_name)
                 os_date_formats.append(os_date_format)
-            elif include_timestamp and is_datetime_or_timedelta_dtype(pd_dtype):
+            elif include_timestamp and (is_datetime64_any_dtype(pd_dtype) or is_timedelta64_dtype(pd_dtype)):
                 pd_dtypes.append(np.dtype(pd_dtype))
                 os_field_names.append(os_field_name)
                 os_date_formats.append(os_date_format)

--- a/opensearch_py_ml/field_mappings.py
+++ b/opensearch_py_ml/field_mappings.py
@@ -91,7 +91,9 @@ class Field(NamedTuple):
 
     @property
     def is_timestamp(self) -> bool:
-        return is_datetime64_any_dtype(self.pd_dtype) or is_timedelta64_dtype(self.pd_dtype)
+        return is_datetime64_any_dtype(self.pd_dtype) or is_timedelta64_dtype(
+            self.pd_dtype
+        )
 
     @property
     def is_bool(self) -> bool:
@@ -794,7 +796,9 @@ class FieldMappings:
                 pd_dtypes.append(np.dtype(pd_dtype))
                 os_field_names.append(os_field_name)
                 os_date_formats.append(os_date_format)
-            elif include_timestamp and (is_datetime64_any_dtype(pd_dtype) or is_timedelta64_dtype(pd_dtype)):
+            elif include_timestamp and (
+                is_datetime64_any_dtype(pd_dtype) or is_timedelta64_dtype(pd_dtype)
+            ):
                 pd_dtypes.append(np.dtype(pd_dtype))
                 os_field_names.append(os_field_name)
                 os_date_formats.append(os_date_format)

--- a/opensearch_py_ml/field_mappings.py
+++ b/opensearch_py_ml/field_mappings.py
@@ -43,10 +43,10 @@ import pandas as pd  # type: ignore
 from pandas.core.dtypes.common import is_bool_dtype  # type: ignore
 from pandas.core.dtypes.common import (
     is_datetime64_any_dtype,
-    is_timedelta64_dtype,
     is_float_dtype,
     is_integer_dtype,
     is_string_dtype,
+    is_timedelta64_dtype,
 )
 from pandas.core.dtypes.inference import is_list_like
 


### PR DESCRIPTION
### Description
removes deprecated `is_datetime_or_timedelta_dtype`  usage
 
### Issues Resolved
#263 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
