### PR TITLE
reordering ml_commons tests : moved test_search to the end 

### DIFF
--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -420,7 +420,7 @@ def test_integration_model_train_register_full_cycle():
 
 
 def test_search():
-    # Search task cases
+    # Search tasks
     raised = False
     try:
         search_task_obj = ml_client.search_task(

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -100,102 +100,6 @@ def test_execute():
     ), "Raised Exception during execute API testing with JSON string"
 
 
-def test_search():
-    # Search task cases
-    raised = False
-    try:
-        search_task_obj = ml_client.search_task(
-            input_json='{"query": {"match_all": {}},"size": 1}'
-        )
-        assert search_task_obj["hits"]["hits"] != []
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching task"
-
-    raised = False
-    try:
-        search_task_obj = ml_client.search_task(
-            input_json={"query": {"match_all": {}}, "size": 1}
-        )
-        assert search_task_obj["hits"]["hits"] != []
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching task"
-
-    raised = False
-    try:
-        search_task_obj = ml_client.search_task(input_json=15)
-        assert search_task_obj == "Invalid JSON object passed as argument."
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching task"
-
-    raised = False
-    try:
-        search_task_obj = ml_client.search_task(input_json="15")
-        assert search_task_obj == "Invalid JSON object passed as argument."
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching task"
-
-    raised = False
-    try:
-        search_task_obj = ml_client.search_task(
-            input_json='{"query": {"match_all": {}},size: 1}'
-        )
-        assert search_task_obj == "Invalid JSON string passed as argument."
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching task"
-
-    # Search model cases
-    raised = False
-    try:
-        search_model_obj = ml_client.search_model(
-            input_json='{"query": {"match_all": {}},"size": 1}'
-        )
-        assert search_model_obj["hits"]["hits"] != []
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching model"
-
-    raised = False
-    try:
-        search_model_obj = ml_client.search_model(
-            input_json={"query": {"match_all": {}}, "size": 1}
-        )
-        assert search_model_obj["hits"]["hits"] != []
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching model"
-
-    raised = False
-    try:
-        search_model_obj = ml_client.search_model(input_json=15)
-        assert search_model_obj == "Invalid JSON object passed as argument."
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching model"
-
-    raised = False
-    try:
-        search_model_obj = ml_client.search_model(input_json="15")
-        assert search_model_obj == "Invalid JSON object passed as argument."
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching model"
-
-    raised = False
-    try:
-        search_model_obj = ml_client.search_model(
-            input_json='{"query": {"match_all": {}},size: 1}'
-        )
-        assert search_model_obj == "Invalid JSON string passed as argument."
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching model"
-
-
 def test_DEPRECATED_integration_pretrained_model_upload_unload_delete():
     raised = False
     try:
@@ -515,4 +419,97 @@ def test_integration_model_train_register_full_cycle():
                 assert raised == False, "Raised Exception in deleting model"
 
 
-test_integration_model_train_register_full_cycle()
+def test_search():
+    # Search task cases
+    raised = False
+    try:
+        search_task_obj = ml_client.search_task(
+            input_json='{"query": {"match_all": {}},"size": 1}'
+        )
+        assert search_task_obj["hits"]["hits"] != []
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching task"
+
+    raised = False
+    try:
+        search_task_obj = ml_client.search_task(
+            input_json={"query": {"match_all": {}}, "size": 1}
+        )
+        assert search_task_obj["hits"]["hits"] != []
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching task"
+
+    raised = False
+    try:
+        search_task_obj = ml_client.search_task(input_json=15)
+        assert search_task_obj == "Invalid JSON object passed as argument."
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching task"
+
+    raised = False
+    try:
+        search_task_obj = ml_client.search_task(input_json="15")
+        assert search_task_obj == "Invalid JSON object passed as argument."
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching task"
+
+    raised = False
+    try:
+        search_task_obj = ml_client.search_task(
+            input_json='{"query": {"match_all": {}},size: 1}'
+        )
+        assert search_task_obj == "Invalid JSON string passed as argument."
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching task"
+
+    # Search model cases
+    raised = False
+    try:
+        search_model_obj = ml_client.search_model(
+            input_json='{"query": {"match_all": {}},"size": 1}'
+        )
+        assert search_model_obj["hits"]["hits"] != []
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching model"
+
+    raised = False
+    try:
+        search_model_obj = ml_client.search_model(
+            input_json={"query": {"match_all": {}}, "size": 1}
+        )
+        assert search_model_obj["hits"]["hits"] != []
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching model"
+
+    raised = False
+    try:
+        search_model_obj = ml_client.search_model(input_json=15)
+        assert search_model_obj == "Invalid JSON object passed as argument."
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching model"
+
+    raised = False
+    try:
+        search_model_obj = ml_client.search_model(input_json="15")
+        assert search_model_obj == "Invalid JSON object passed as argument."
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching model"
+
+    raised = False
+    try:
+        search_model_obj = ml_client.search_model(
+            input_json='{"query": {"match_all": {}},size: 1}'
+        )
+        assert search_model_obj == "Invalid JSON string passed as argument."
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching model"


### PR DESCRIPTION
Fixes #326 


Having `test_search` at the start of the module is making it to run first.  Since pytest runs tests by the [order they appear in the module](https://pytest-ordering.readthedocs.io/en/develop/#quickstart). Moving `test_search` to the end should help to mitigate this issue

### Check List
- [] New functionality includes testing.
  - [] All tests pass
- [] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).