### PR TITLE
reordering ml_commons tests : moved test_search to the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update model upload history -  sentence-transformers/distiluse-base-multilingual-cased-v1 (v.1.0.1)(TORCH_SCRIPT) by @dhrubo-os ([#281](https://github.com/opensearch-project/opensearch-py-ml/pull/281))
 - Update pretrained_models_all_versions.json (2023-09-14 10:28:41) by @dhrubo-os ([#282](https://github.com/opensearch-project/opensearch-py-ml/pull/282))
 - Enable the model upload workflow to add model_content_size_in_bytes & model_content_hash_value to model config automatically @thanawan-atc ([#291](https://github.com/opensearch-project/opensearch-py-ml/pull/291))
+- Update pretrained_models_all_versions.json (2023-10-18 18:11:34) by @dhrubo-os ([#322](https://github.com/opensearch-project/opensearch-py-ml/pull/322))
 - Update model upload history -  sentence-transformers/paraphrase-mpnet-base-v2 (v.1.0.0)(BOTH) by @dhrubo-os ([#321](https://github.com/opensearch-project/opensearch-py-ml/pull/321))
 
 ### Fixed

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 #
 # Basic requirements
 #
-pandas>=1.5.2,<3
+pandas>=1.5.2,<2
 matplotlib>=3.6.2,<4
 numpy>=1.24.0,<2
 opensearch-py>=2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 #
 # Basic requirements
 #
-pandas>=1.5.2,<3
+pandas>=1.5.2,<2
 matplotlib>=3.6.2,<4
 numpy>=1.24.0,<2
 opensearch-py>=2.2.0

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -100,9 +100,6 @@ def test_execute():
     ), "Raised Exception during execute API testing with JSON string"
 
 
-
-
-
 def test_DEPRECATED_integration_pretrained_model_upload_unload_delete():
     raised = False
     try:
@@ -420,6 +417,7 @@ def test_integration_model_train_register_full_cycle():
                 except:  # noqa: E722
                     raised = True
                 assert raised == False, "Raised Exception in deleting model"
+
 
 def test_search():
     # Search task cases

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -420,7 +420,7 @@ def test_integration_model_train_register_full_cycle():
 
 
 def test_search():
-    # Search task cases
+    # Search task cases tests
     raised = False
     try:
         search_task_obj = ml_client.search_task(

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -100,100 +100,7 @@ def test_execute():
     ), "Raised Exception during execute API testing with JSON string"
 
 
-def test_search():
-    # Search task cases
-    raised = False
-    try:
-        search_task_obj = ml_client.search_task(
-            input_json='{"query": {"match_all": {}},"size": 1}'
-        )
-        assert search_task_obj["hits"]["hits"] != []
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching task"
 
-    raised = False
-    try:
-        search_task_obj = ml_client.search_task(
-            input_json={"query": {"match_all": {}}, "size": 1}
-        )
-        assert search_task_obj["hits"]["hits"] != []
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching task"
-
-    raised = False
-    try:
-        search_task_obj = ml_client.search_task(input_json=15)
-        assert search_task_obj == "Invalid JSON object passed as argument."
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching task"
-
-    raised = False
-    try:
-        search_task_obj = ml_client.search_task(input_json="15")
-        assert search_task_obj == "Invalid JSON object passed as argument."
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching task"
-
-    raised = False
-    try:
-        search_task_obj = ml_client.search_task(
-            input_json='{"query": {"match_all": {}},size: 1}'
-        )
-        assert search_task_obj == "Invalid JSON string passed as argument."
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching task"
-
-    # Search model cases
-    raised = False
-    try:
-        search_model_obj = ml_client.search_model(
-            input_json='{"query": {"match_all": {}},"size": 1}'
-        )
-        assert search_model_obj["hits"]["hits"] != []
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching model"
-
-    raised = False
-    try:
-        search_model_obj = ml_client.search_model(
-            input_json={"query": {"match_all": {}}, "size": 1}
-        )
-        assert search_model_obj["hits"]["hits"] != []
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching model"
-
-    raised = False
-    try:
-        search_model_obj = ml_client.search_model(input_json=15)
-        assert search_model_obj == "Invalid JSON object passed as argument."
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching model"
-
-    raised = False
-    try:
-        search_model_obj = ml_client.search_model(input_json="15")
-        assert search_model_obj == "Invalid JSON object passed as argument."
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching model"
-
-    raised = False
-    try:
-        search_model_obj = ml_client.search_model(
-            input_json='{"query": {"match_all": {}},size: 1}'
-        )
-        assert search_model_obj == "Invalid JSON string passed as argument."
-    except:  # noqa: E722
-        raised = True
-    assert raised == False, "Raised Exception in searching model"
 
 
 def test_DEPRECATED_integration_pretrained_model_upload_unload_delete():
@@ -514,5 +421,97 @@ def test_integration_model_train_register_full_cycle():
                     raised = True
                 assert raised == False, "Raised Exception in deleting model"
 
+def test_search():
+    # Search task cases
+    raised = False
+    try:
+        search_task_obj = ml_client.search_task(
+            input_json='{"query": {"match_all": {}},"size": 1}'
+        )
+        assert search_task_obj["hits"]["hits"] != []
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching task"
 
-test_integration_model_train_register_full_cycle()
+    raised = False
+    try:
+        search_task_obj = ml_client.search_task(
+            input_json={"query": {"match_all": {}}, "size": 1}
+        )
+        assert search_task_obj["hits"]["hits"] != []
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching task"
+
+    raised = False
+    try:
+        search_task_obj = ml_client.search_task(input_json=15)
+        assert search_task_obj == "Invalid JSON object passed as argument."
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching task"
+
+    raised = False
+    try:
+        search_task_obj = ml_client.search_task(input_json="15")
+        assert search_task_obj == "Invalid JSON object passed as argument."
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching task"
+
+    raised = False
+    try:
+        search_task_obj = ml_client.search_task(
+            input_json='{"query": {"match_all": {}},size: 1}'
+        )
+        assert search_task_obj == "Invalid JSON string passed as argument."
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching task"
+
+    # Search model cases
+    raised = False
+    try:
+        search_model_obj = ml_client.search_model(
+            input_json='{"query": {"match_all": {}},"size": 1}'
+        )
+        assert search_model_obj["hits"]["hits"] != []
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching model"
+
+    raised = False
+    try:
+        search_model_obj = ml_client.search_model(
+            input_json={"query": {"match_all": {}}, "size": 1}
+        )
+        assert search_model_obj["hits"]["hits"] != []
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching model"
+
+    raised = False
+    try:
+        search_model_obj = ml_client.search_model(input_json=15)
+        assert search_model_obj == "Invalid JSON object passed as argument."
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching model"
+
+    raised = False
+    try:
+        search_model_obj = ml_client.search_model(input_json="15")
+        assert search_model_obj == "Invalid JSON object passed as argument."
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching model"
+
+    raised = False
+    try:
+        search_model_obj = ml_client.search_model(
+            input_json='{"query": {"match_all": {}},size: 1}'
+        )
+        assert search_model_obj == "Invalid JSON string passed as argument."
+    except:  # noqa: E722
+        raised = True
+    assert raised == False, "Raised Exception in searching model"

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -420,7 +420,7 @@ def test_integration_model_train_register_full_cycle():
 
 
 def test_search():
-    # Search task cases tests
+    # Search task cases
     raised = False
     try:
         search_task_obj = ml_client.search_task(

--- a/utils/model_uploader/model_listing/pretrained_models_all_versions.json
+++ b/utils/model_uploader/model_listing/pretrained_models_all_versions.json
@@ -114,6 +114,18 @@
     }
   },
   {
+    "name": "huggingface/sentence-transformers/paraphrase-mpnet-base-v2",
+    "versions": {
+      "1.0.0": {
+        "format": [
+          "onnx",
+          "torch_script"
+        ],
+        "description": "This is a sentence-transformers model: It maps sentences & paragraphs to a 768 dimensional dense vector space and can be used for tasks like clustering or semantic search."
+      }
+    }
+  },
+  {
     "name": "huggingface/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
     "versions": {
       "1.0.1": {
@@ -122,17 +134,6 @@
           "torch_script"
         ],
         "description": "This is a sentence-transformers model: It maps sentences & paragraphs to a 384 dimensional dense vector space and can be used for tasks like clustering or semantic search."
-      }
-    }
-  },
-  {
-    "name": "amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v1",
-    "versions": {
-      "1.0.0": {
-        "format": [
-          "torch_script"
-        ],
-        "description": "This is a neural sparse encoding model: It transfers text into sparse vector, and then extract nonzero index and value to entry and weights. It serves only in ingestion and customer should use tokenizer model in query."
       }
     }
   }


### PR DESCRIPTION
Fixes #326 


Having `test_search` at the start of the module is making it to run first.  Since pytest runs tests by the [order they appear in the module](https://pytest-ordering.readthedocs.io/en/develop/#quickstart). Moving `test_search` to the end should help to mitigate this issue
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
