### PR TITLE
Add GitHub action for opensearch-py-ml release

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   draft-a-release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -34,10 +37,11 @@ jobs:
         run: |
           python -m build
           tar -zvcf artifacts.tar.gz dist
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
       - name: Draft a release
         uses: softprops/action-gh-release@v1
         with:
-          draft: true
           generate_release_notes: true
           files: |
             artifacts.tar.gz


### PR DESCRIPTION
### Description
Enable GHA release by adding trusted publisher.
This workflow will be triggered when a tag is pushed to this repository. The workflow will built the product and publish to Pypi.
The GitHub release will be created after publishing to Pypi with `artifacts.tar.gz`.

I will add this workflow as trusted publisher according to this. https://docs.pypi.org/trusted-publishers/adding-a-publisher/ 

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build-libraries/issues/222
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
