### PR TITLE
Transition to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "opensearch-py-ml"
+description = "OpenSearch Python Machine Learning Library"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {file = "LICENSE.txt"}
+dependencies = [
+    "opensearch-py>=2",
+    "pandas>=1.5,<3",
+    "matplotlib>=3.6.0,<4",
+    "numpy>=1.24.0,<2",
+    "deprecated>=1.2.14,<2",
+]
+
+# ToDo: get from "about" dict in setup.py 
+[project.urls] 
+homepage = "https://opensearch-project.github.io/opensearch-py-ml/index.html"
+documentation = "https://opensearch.org/docs/latest/clients/opensearch-py-ml/"
+repository = "https://github.com/opensearch-project/opensearch-py-ml"
+changelog = "https://github.com/opensearch-project/opensearch-py-ml/blob/main/CHANGELOG.md"


### PR DESCRIPTION
### Description
Aims to transition the project `opensearch-py-ml` from `setup.py` and `setup.cfg` to `pyproject.toml` of the [PEP 621](https://peps.python.org/pep-0621/) standard
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-py-ml/issues/308

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
