### PR TITLE
Bug fix for: Only require model_id once to save a modelreq 

### DIFF
--- a/opensearch_py_ml/ml_models/sentencetransformermodel.py
+++ b/opensearch_py_ml/ml_models/sentencetransformermodel.py
@@ -92,7 +92,7 @@ class SentenceTransformerModel:
                 str("The default folder path already exists at : " + self.folder_path)
             )
 
-        self.model_id = model_id
+        self.model_id = model_id if model_id is not None else self.DEFAULT_MODEL_ID
         self.torch_script_zip_file_path = None
         self.onnx_zip_file_path = None
 
@@ -806,7 +806,7 @@ class SentenceTransformerModel:
         :rtype: string
         """
 
-        model = SentenceTransformer(model_id)
+        model = SentenceTransformer(self.model_id)
 
         if model_name is None:
             model_name = str(model_id.split("/")[-1] + ".pt")


### PR DESCRIPTION
### Description
In this pull request, I implemented a bug fix in opensearch_py_ml/ml_models/sentencetransformermodel.py to ensure that model_id is only required once for saving a model. Comprehensive tests were added in tests/ml_commons/test_ml_commons_client.py and tests/ml_models/test_sentencetransformermodel_pytest.py to validate the functionality.
 
### Issues Resolved
#323 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
