### PR TITLE
Fix incorrect version pin in `setup.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix pandas dependency issue in nox session by installing pandas package to python directly by @thanawan-atc in ([#266](https://github.com/opensearch-project/opensearch-py-ml/pull/266))
 - Fix conditional job execution issue in model upload workflow by @thanawan-atc in ([#294](https://github.com/opensearch-project/opensearch-py-ml/pull/294))
 - fix bug in `MLCommonClient_client.upload_model` by @rawwar in ([#336](https://github.com/opensearch-project/opensearch-py-ml/pull/336))
+- fixed pandas versions in setup.py to match to the ones used for testing by @rawwar in ([#369](https://github.com/opensearch-project/opensearch-py-ml/pull/369))
 
 ## [1.1.0]
 

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     },
     install_requires=[
         "opensearch-py>=2",
-        "pandas>=1.5,<3",
+        "pandas>=1.5.2,<2",
         "matplotlib>=3.6.0,<4",
         "numpy>=1.24.0,<2",
         "deprecated>=1.2.14,<2",


### PR DESCRIPTION
### Description
Currently, Pins in setup.py is different from the ones we mention in requirements.txt. hence updating it.
 
### Issues Resolved
NA
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
