### PR TITLE
Switch AL2 to AL2023 agent and DockerHub to ECR images in ml-models.JenkinsFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Replaced usage of `is_datetime_or_timedelta_dtype` with `is_timedelta64_dtype` and `is_datetime64_any_dtype` by @rawwar ([#316](https://github.com/opensearch-project/opensearch-py-ml/pull/316))
 - use try-except-else block for handling unexpected exceptions during integration tests by @rawwar([#370](https://github.com/opensearch-project/opensearch-py-ml/pull/370))
 - Removed pandas version pin in nox tests by @rawwar ([#368](https://github.com/opensearch-project/opensearch-py-ml/pull/368))
+- Switch AL2 to AL2023 agent and DockerHub to ECR images in ml-models.JenkinsFile ([#377](https://github.com/opensearch-project/opensearch-py-ml/pull/377))
 
 ### Fixed
 - Enable make_model_config_json to add model description to model config file by @thanawan-atc in ([#203](https://github.com/opensearch-project/opensearch-py-ml/pull/203))

--- a/jenkins/ml-models.JenkinsFile
+++ b/jenkins/ml-models.JenkinsFile
@@ -7,8 +7,9 @@ pipeline {
     agent
     {
         docker {
-            label 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host'
+            label 'Jenkins-Agent-AL2023-X64-C54xlarge-Docker-Host'
             image 'opensearchstaging/ci-runner:release-centos7-clients-v4'
+            registryUrl 'https://public.ecr.aws/'
             alwaysPull true
         }
     }


### PR DESCRIPTION
### Description
Switch AL2 to AL2023 agent and DockerHub to ECR images

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-py-ml/issues/376
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
