### PR TITLE
added sort_index parameter to DataFrame.to_pandas function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # CHANGELOG
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased 1.x]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Fixed DataFrame.to_pandas duplication bug by adding query_compiler object method by @Arnav-Gr0ver in ([#392](https://github.com/opensearch-project/opensearch-py-ml/pull/392))
+
 ## [1.2.0]
 
 ### Added

--- a/opensearch_py_ml/operations.py
+++ b/opensearch_py_ml/operations.py
@@ -1228,7 +1228,7 @@ class Operations:
     ) -> pd.DataFrame:
         df_list: List[pd.DataFrame] = []
         i = 0
-        for df in self.search_yield_pandas_dataframes(query_compiler=query_compiler, sort_index=os_index_field):
+        for df in self.search_yield_pandas_dataframes(query_compiler=query_compiler, sort_index=query_compiler.index.os_index_field):
             if show_progress:
                 i = i + df.shape[0]
                 if i % DEFAULT_PROGRESS_REPORTING_NUM_ROWS == 0:

--- a/opensearch_py_ml/operations.py
+++ b/opensearch_py_ml/operations.py
@@ -1537,7 +1537,7 @@ def _search_yield_hits(
     # Pagination with 'search_after' must have a 'sort' setting.
     # Using '_doc:asc' is the most efficient as reads documents
     # in the order that they're written on disk in Lucene.
-    body.setdefault("sort", [{sort_index: "asc"}])
+    body.setdefault("sort", [{sort_index: sort_index}])
 
     # Improves performance by not tracking # of hits. We only
     # care about the hit itself for these queries.

--- a/opensearch_py_ml/operations.py
+++ b/opensearch_py_ml/operations.py
@@ -1228,7 +1228,7 @@ class Operations:
     ) -> pd.DataFrame:
         df_list: List[pd.DataFrame] = []
         i = 0
-        for df in self.search_yield_pandas_dataframes(query_compiler=query_compiler):
+        for df in self.search_yield_pandas_dataframes(query_compiler=query_compiler, sort_index=os_index_field):
             if show_progress:
                 i = i + df.shape[0]
                 if i % DEFAULT_PROGRESS_REPORTING_NUM_ROWS == 0:

--- a/opensearch_py_ml/operations.py
+++ b/opensearch_py_ml/operations.py
@@ -1228,7 +1228,10 @@ class Operations:
     ) -> pd.DataFrame:
         df_list: List[pd.DataFrame] = []
         i = 0
-        for df in self.search_yield_pandas_dataframes(query_compiler=query_compiler, sort_index=query_compiler.index.os_index_field):
+        for df in self.search_yield_pandas_dataframes(
+            query_compiler=query_compiler,
+            sort_index=query_compiler.index.os_index_field,
+        ):
             if show_progress:
                 i = i + df.shape[0]
                 if i % DEFAULT_PROGRESS_REPORTING_NUM_ROWS == 0:


### PR DESCRIPTION
### Description
Resolves DataFrame.to_pandas duplication bug when an os_index_field is set, following expected behavior
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-py-ml/issues/382
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
