### PR TITLE
[Fix] Model uploader's jekins trigger parameter fix

### DIFF
--- a/.github/workflows/model_uploader.yml
+++ b/.github/workflows/model_uploader.yml
@@ -74,6 +74,16 @@ jobs:
          echo "This workflow should only be triggered on 'main' branch"
          exit 1
     - name: Initiate folders
+      # This scripts init the folders path variables.
+      # 1. Retrieves the input model_id.
+      # 2. If upload_prefix is provided, constructs model_prefix using upload_prefix and model_source.
+      #    - model_prefix: "ml-models/{model_source}/{upload_prefix}"
+      # 3. If upload_prefix is not provided, it constructs model_prefix using model_source and the prefix part of model_id.
+      #    - The prefix part is the substring before the first '/' in model_id.
+      #    Example:
+      #    - Given model_id: "opensearch-project/opensearch-neural-sparse-encoding-v1"
+      #    - model_prefix: "ml-models/{model_source}/opensearch-project"
+      # 4. Constructs model_folder and model_prefix_folder.
       id: init_folders
       run: |
         model_id=${{ github.event.inputs.model_id }}

--- a/.github/workflows/model_uploader.yml
+++ b/.github/workflows/model_uploader.yml
@@ -24,6 +24,10 @@ on:
         - "BOTH"
         - "TORCH_SCRIPT"
         - "ONNX"
+      upload_prefix:
+        description: "Specifies the model prefix for uploading. For example, transforming the default path from '.../sentence-transformers/msmarco-distilbert-base-tas-b' to '.../{prefix}/msmarco-distilbert-base-tas-b'."
+        required: false
+        type: string
       model_type:
         description: "Model type for auto-tracing (SentenceTransformer/Sparse)"
         required: true
@@ -74,7 +78,12 @@ jobs:
       run: |
         model_id=${{ github.event.inputs.model_id }}
         echo "model_folder=ml-models/${{github.event.inputs.model_source}}/${model_id}" >> $GITHUB_OUTPUT
-        echo "model_prefix_folder=ml-models/${{github.event.inputs.model_source}}/${model_id%%/*}/" >> $GITHUB_OUTPUT
+        if [[ -n "${{ github.event.inputs.upload_prefix }}" ]]; then
+          model_prefix="ml-models/${{ github.event.inputs.model_source }}/${{ github.event.inputs.upload_prefix }}"
+        else
+          model_prefix="ml-models/${{ github.event.inputs.model_source }}/${model_id%%/*}"
+        fi
+        echo "model_prefix_folder=$model_prefix" >> $GITHUB_OUTPUT
     - name: Initiate workflow_info
       id: init_workflow_info
       run: |

--- a/.github/workflows/model_uploader.yml
+++ b/.github/workflows/model_uploader.yml
@@ -77,12 +77,12 @@ jobs:
       id: init_folders
       run: |
         model_id=${{ github.event.inputs.model_id }}
-        echo "model_folder=ml-models/${{github.event.inputs.model_source}}/${model_id}" >> $GITHUB_OUTPUT
         if [[ -n "${{ github.event.inputs.upload_prefix }}" ]]; then
           model_prefix="ml-models/${{ github.event.inputs.model_source }}/${{ github.event.inputs.upload_prefix }}"
         else
           model_prefix="ml-models/${{ github.event.inputs.model_source }}/${model_id%%/*}"
         fi
+        echo "model_folder=$model_prefix/${model_id##*/}" >> $GITHUB_OUTPUT
         echo "model_prefix_folder=$model_prefix" >> $GITHUB_OUTPUT
     - name: Initiate workflow_info
       id: init_workflow_info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed pandas version pin in nox tests by @rawwar ([#368](https://github.com/opensearch-project/opensearch-py-ml/pull/368))
 - Switch AL2 to AL2023 agent and DockerHub to ECR images in ml-models.JenkinsFile ([#377](https://github.com/opensearch-project/opensearch-py-ml/pull/377))
 - Refactored validators in ML Commons' client([#385](https://github.com/opensearch-project/opensearch-py-ml/pull/385))
-- Update model upload history -  opensearch-project/opensearch-neural-sparse-encoding-doc-v2-distill (v.1.0.0)(TORCH_SCRIPT) by @dhrubo-os ([#400](https://github.com/opensearch-project/opensearch-py-ml/pull/400))
 
 ### Fixed
+- Fix the wrong input parameter for model_uploader's base_download_path in jekins trigger.([#402](https://github.com/opensearch-project/opensearch-py-ml/pull/402))
 - Enable make_model_config_json to add model description to model config file by @thanawan-atc in ([#203](https://github.com/opensearch-project/opensearch-py-ml/pull/203))
 - Correct demo_ml_commons_integration.ipynb by @thanawan-atc in ([#208](https://github.com/opensearch-project/opensearch-py-ml/pull/208))
 - Handle the case when the model max length is undefined in tokenizer by @thanawan-atc in ([#219](https://github.com/opensearch-project/opensearch-py-ml/pull/219))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add workflows and scripts for sparse encoding model tracing and uploading process by @conggguan in ([#394](https://github.com/opensearch-project/opensearch-py-ml/pull/394))
 
 ### Changed
+- Add a parameter for customize the upload folder prefix ([#398](https://github.com/opensearch-project/opensearch-py-ml/pull/398))
 - Modify ml-models.JenkinsFile so that it takes model format into account and can be triggered with generic webhook by @thanawan-atc in ([#211](https://github.com/opensearch-project/opensearch-py-ml/pull/211))
 - Update demo_tracing_model_torchscript_onnx.ipynb to use make_model_config_json by @thanawan-atc in ([#220](https://github.com/opensearch-project/opensearch-py-ml/pull/220))
 - Bump torch from 1.13.1 to 2.0.1 and add onnx dependency by @thanawan-atc ([#237](https://github.com/opensearch-project/opensearch-py-ml/pull/237))

--- a/utils/model_uploader/upload_history/MODEL_UPLOAD_HISTORY.md
+++ b/utils/model_uploader/upload_history/MODEL_UPLOAD_HISTORY.md
@@ -21,4 +21,3 @@ The following table shows sentence transformer model upload history.
 |2023-09-13 18:03:32|@dhrubo-os|`sentence-transformers/distiluse-base-multilingual-cased-v1`|1.0.1|TORCH_SCRIPT|N/A|N/A|6178024517|
 |2023-10-18 18:06:15|@dhrubo-os|`sentence-transformers/paraphrase-mpnet-base-v2`|1.0.0|ONNX|N/A|N/A|6568285400|
 |2023-10-18 18:06:15|@dhrubo-os|`sentence-transformers/paraphrase-mpnet-base-v2`|1.0.0|TORCH_SCRIPT|N/A|N/A|6568285400|
-|2024-08-06 12:42:00|@dhrubo-os|`opensearch-project/opensearch-neural-sparse-encoding-doc-v2-distill`|1.0.0|TORCH_SCRIPT|N/A|N/A|10271804648|

--- a/utils/model_uploader/upload_history/supported_models.json
+++ b/utils/model_uploader/upload_history/supported_models.json
@@ -48,15 +48,5 @@
         "Embedding Dimension": "N/A",
         "Pooling Mode": "N/A",
         "Workflow Run ID": "6568285400"
-    },
-    {
-        "Model Uploader": "@dhrubo-os",
-        "Upload Time": "2024-08-06 12:42:00",
-        "Model ID": "opensearch-project/opensearch-neural-sparse-encoding-doc-v2-distill",
-        "Model Version": "1.0.0",
-        "Model Format": "TORCH_SCRIPT",
-        "Embedding Dimension": "N/A",
-        "Pooling Mode": "N/A",
-        "Workflow Run ID": "10271804648"
     }
 ]


### PR DESCRIPTION
### Description
Current model upload workflow has a parameter which can customize the prefix of the upload path. But the Jekins's release workflow are miss this point so that will failed. 
In this PR, removed the redundant failed model update information and fixed this bug.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
