### PR TITLE
refactor: replace `payload` with `body` for consistency with OpenSearch API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - fix bug in `MLCommonClient_client.upload_model` by @rawwar in ([#336](https://github.com/opensearch-project/opensearch-py-ml/pull/336))
 - fix lint issues on main by @rawwar in ([#374](https://github.com/opensearch-project/opensearch-py-ml/pull/374))
 - fix CVE vulnerability by @rawwar in ([#383](https://github.com/opensearch-project/opensearch-py-ml/pull/383))
+- refactor: replace 'payload' with 'body' in `create_standalone_connector` by @yerzhaisang ([#424](https://github.com/opensearch-project/opensearch-py-ml/pull/424))
 
 ## [1.1.0]
 

--- a/opensearch_py_ml/ml_commons/model_connector.py
+++ b/opensearch_py_ml/ml_commons/model_connector.py
@@ -17,19 +17,30 @@ class Connector:
         self.client = os_client
 
     def create_standalone_connector(self, body: dict = None, payload: dict = None):
-        if body is None:
-            if payload is not None:
-                if not isinstance(payload, dict):
-                    raise ValueError("'payload' needs to be a dictionary.")
-                warnings.warn(
-                    "The 'payload' argument is deprecated; use 'body' instead.",
-                    DeprecationWarning,
-                )
-                body = payload
-            else:
-                raise ValueError("'body' needs to be provided as a dictionary.")
+        """
+        Create a standalone connector. 
 
-        elif not isinstance(body, dict):
+        Parameters:
+            body (dict): The request body, preferred parameter.
+            payload (dict): Deprecated. Use 'body' instead.
+            
+        Raises:
+            ValueError: If neither 'body' nor 'payload' is provided or if the provided argument is not a dictionary.
+        """
+        if body is None and payload is None:
+            raise ValueError("A 'body' parameter must be provided as a dictionary.")
+
+        if payload is not None:
+            if not isinstance(payload, dict):
+                raise ValueError("'payload' needs to be a dictionary.")
+            warnings.warn(
+                "'payload' is deprecated. Please use 'body' instead.",
+                DeprecationWarning,
+            )
+            # Use `payload` if `body` is not provided for backward compatibility
+            body = body or payload
+
+        if not isinstance(body, dict):
             raise ValueError("'body' needs to be a dictionary.")
 
         return self.client.transport.perform_request(

--- a/opensearch_py_ml/ml_commons/model_connector.py
+++ b/opensearch_py_ml/ml_commons/model_connector.py
@@ -18,12 +18,12 @@ class Connector:
 
     def create_standalone_connector(self, body: dict = None, payload: dict = None):
         """
-        Create a standalone connector. 
+        Create a standalone connector.
 
         Parameters:
             body (dict): The request body, preferred parameter.
             payload (dict): Deprecated. Use 'body' instead.
-            
+
         Raises:
             ValueError: If neither 'body' nor 'payload' is provided or if the provided argument is not a dictionary.
         """

--- a/opensearch_py_ml/ml_commons/model_connector.py
+++ b/opensearch_py_ml/ml_commons/model_connector.py
@@ -8,18 +8,28 @@
 from opensearchpy import OpenSearch
 
 from opensearch_py_ml.ml_commons.ml_common_utils import ML_BASE_URI
+import warnings
 
 
 class Connector:
     def __init__(self, os_client: OpenSearch):
         self.client = os_client
 
-    def create_standalone_connector(self, payload: dict):
-        if not isinstance(payload, dict):
-            raise ValueError("payload needs to be a dictionary")
+    def create_standalone_connector(self, body: dict = None, payload: dict = None):
+        if body is None:
+            if payload is not None:
+                if not isinstance(payload, dict):
+                    raise ValueError("'payload' needs to be a dictionary.")
+                warnings.warn("The 'payload' argument is deprecated; use 'body' instead.", DeprecationWarning)
+                body = payload
+            else:
+                raise ValueError("'body' needs to be provided as a dictionary.")
+
+        elif not isinstance(body, dict):
+            raise ValueError("'body' needs to be a dictionary.")
 
         return self.client.transport.perform_request(
-            method="POST", url=f"{ML_BASE_URI}/connectors/_create", body=payload
+            method="POST", url=f"{ML_BASE_URI}/connectors/_create", body=body
         )
 
     def list_connectors(self):

--- a/opensearch_py_ml/ml_commons/model_connector.py
+++ b/opensearch_py_ml/ml_commons/model_connector.py
@@ -5,10 +5,11 @@
 # Any modifications Copyright OpenSearch Contributors. See
 # GitHub history for details.
 
+import warnings
+
 from opensearchpy import OpenSearch
 
 from opensearch_py_ml.ml_commons.ml_common_utils import ML_BASE_URI
-import warnings
 
 
 class Connector:
@@ -20,7 +21,10 @@ class Connector:
             if payload is not None:
                 if not isinstance(payload, dict):
                     raise ValueError("'payload' needs to be a dictionary.")
-                warnings.warn("The 'payload' argument is deprecated; use 'body' instead.", DeprecationWarning)
+                warnings.warn(
+                    "The 'payload' argument is deprecated; use 'body' instead.",
+                    DeprecationWarning,
+                )
                 body = payload
             else:
                 raise ValueError("'body' needs to be provided as a dictionary.")

--- a/tests/ml_commons/test_model_connector.py
+++ b/tests/ml_commons/test_model_connector.py
@@ -77,10 +77,7 @@ def test_create_standalone_connector(client: Connector, connector_body: dict):
 
 @pytest.mark.parametrize("invalid_body", ["", None, [], 123])
 def test_create_standalone_connector_invalid_body(client: Connector, invalid_body):
-    with pytest.raises(
-        ValueError,
-        match="A 'body' parameter must be provided as a dictionary|body needs to be a dictionary",
-    ):
+    with pytest.raises(ValueError, match=r"'body' needs to be a dictionary"):
         client.create_standalone_connector(body=invalid_body)
 
 
@@ -90,10 +87,7 @@ def test_create_standalone_connector_invalid_payload(
 ):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        with pytest.raises(
-            ValueError,
-            match="A 'body' parameter must be provided as a dictionary|payload needs to be a dictionary",
-        ):
+        with pytest.raises(ValueError, match=r"'payload' needs to be a dictionary"):
             client.create_standalone_connector(payload=invalid_payload)
         assert any(
             issubclass(warning.category, DeprecationWarning)

--- a/tests/ml_commons/test_model_connector.py
+++ b/tests/ml_commons/test_model_connector.py
@@ -31,7 +31,7 @@ def _safe_delete_connector(client, connector_id):
 
 
 @pytest.fixture
-def connector_payload():
+def connector_body():
     return {
         "name": "Test Connector",
         "description": "Connector for testing",

--- a/tests/ml_commons/test_model_connector.py
+++ b/tests/ml_commons/test_model_connector.py
@@ -64,8 +64,8 @@ def test_connector(client: Connector, connector_body: dict):
     OPENSEARCH_VERSION < CONNECTOR_MIN_VERSION,
     reason="Connectors are supported in OpenSearch 2.9.0 and above",
 )
-def test_create_standalone_connector(client: Connector, connector_payload: dict):
-    res = client.create_standalone_connector(connector_payload)
+def test_create_standalone_connector(client: Connector, connector_body: dict):
+    res = client.create_standalone_connector(connector_body)
     assert "connector_id" in res
 
     _safe_delete_connector(client, res["connector_id"])

--- a/tests/ml_commons/test_model_connector.py
+++ b/tests/ml_commons/test_model_connector.py
@@ -52,8 +52,8 @@ def connector_payload():
 
 
 @pytest.fixture
-def test_connector(client: Connector, connector_payload: dict):
-    res = client.create_standalone_connector(connector_payload)
+def test_connector(client: Connector, connector_body: dict):
+    res = client.create_standalone_connector(connector_body)
     connector_id = res["connector_id"]
     yield connector_id
 

--- a/tests/ml_commons/test_model_connector.py
+++ b/tests/ml_commons/test_model_connector.py
@@ -77,7 +77,10 @@ def test_create_standalone_connector(client: Connector, connector_body: dict):
 
 @pytest.mark.parametrize("invalid_body", ["", None, [], 123])
 def test_create_standalone_connector_invalid_body(client: Connector, invalid_body):
-    with pytest.raises(ValueError, match=r"'body' needs to be a dictionary"):
+    with pytest.raises(
+        ValueError,
+        match=r"A 'body' parameter must be provided as a dictionary|'body' needs to be a dictionary",
+    ):
         client.create_standalone_connector(body=invalid_body)
 
 
@@ -87,7 +90,10 @@ def test_create_standalone_connector_invalid_payload(
 ):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        with pytest.raises(ValueError, match=r"'payload' needs to be a dictionary"):
+        with pytest.raises(
+            ValueError,
+            match=r"A 'body' parameter must be provided as a dictionary|'payload' needs to be a dictionary",
+        ):
             client.create_standalone_connector(payload=invalid_payload)
         assert any(
             issubclass(warning.category, DeprecationWarning)

--- a/tests/ml_commons/test_model_connector.py
+++ b/tests/ml_commons/test_model_connector.py
@@ -94,7 +94,8 @@ def test_create_standalone_connector_invalid_payload(
             ValueError,
             match=r"A 'body' parameter must be provided as a dictionary|'payload' needs to be a dictionary",
         ):
-            client.create_standalone_connector(payload=invalid_payload)
+            client.create_standalone_connector(body=None, payload=invalid_payload)
+
         assert any(
             issubclass(warning.category, DeprecationWarning)
             and "payload is deprecated" in str(warning.message)

--- a/tests/ml_commons/test_model_connector.py
+++ b/tests/ml_commons/test_model_connector.py
@@ -77,7 +77,10 @@ def test_create_standalone_connector(client: Connector, connector_body: dict):
 
 @pytest.mark.parametrize("invalid_body", ["", None, [], 123])
 def test_create_standalone_connector_invalid_body(client: Connector, invalid_body):
-    with pytest.raises(ValueError, match="'body' needs to be a dictionary"):
+    with pytest.raises(
+        ValueError,
+        match="A 'body' parameter must be provided as a dictionary|body needs to be a dictionary",
+    ):
         client.create_standalone_connector(body=invalid_body)
 
 
@@ -87,7 +90,10 @@ def test_create_standalone_connector_invalid_payload(
 ):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        with pytest.raises(ValueError, match="'payload' needs to be a dictionary"):
+        with pytest.raises(
+            ValueError,
+            match="A 'body' parameter must be provided as a dictionary|payload needs to be a dictionary",
+        ):
             client.create_standalone_connector(payload=invalid_payload)
         assert any(
             issubclass(warning.category, DeprecationWarning)

--- a/tests/ml_commons/test_model_connector.py
+++ b/tests/ml_commons/test_model_connector.py
@@ -6,6 +6,7 @@
 # GitHub history for details.
 
 import os
+import warnings
 
 import pytest
 from opensearchpy.exceptions import NotFoundError, RequestError
@@ -72,6 +73,27 @@ def test_create_standalone_connector(client: Connector, connector_body: dict):
 
     with pytest.raises(ValueError):
         client.create_standalone_connector("")
+
+
+@pytest.mark.parametrize("invalid_body", ["", None, [], 123])
+def test_create_standalone_connector_invalid_body(client: Connector, invalid_body):
+    with pytest.raises(ValueError, match="'body' must be a dictionary"):
+        client.create_standalone_connector(body=invalid_body)
+
+
+@pytest.mark.parametrize("invalid_payload", ["", None, [], 123])
+def test_create_standalone_connector_invalid_payload(
+    client: Connector, invalid_payload
+):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        with pytest.raises(ValueError, match="'payload' must be a dictionary"):
+            client.create_standalone_connector(payload=invalid_payload)
+        assert any(
+            issubclass(warning.category, DeprecationWarning)
+            and "payload is deprecated" in str(warning.message)
+            for warning in w
+        ), "A DeprecationWarning for 'payload' should have been raised."
 
 
 @pytest.mark.skipif(

--- a/tests/ml_commons/test_model_connector.py
+++ b/tests/ml_commons/test_model_connector.py
@@ -6,7 +6,6 @@
 # GitHub history for details.
 
 import os
-import warnings
 
 import pytest
 from opensearchpy.exceptions import NotFoundError, RequestError
@@ -82,25 +81,6 @@ def test_create_standalone_connector_invalid_body(client: Connector, invalid_bod
         match=r"A 'body' parameter must be provided as a dictionary|'body' needs to be a dictionary",
     ):
         client.create_standalone_connector(body=invalid_body)
-
-
-@pytest.mark.parametrize("invalid_payload", ["", None, [], 123])
-def test_create_standalone_connector_invalid_payload(
-    client: Connector, invalid_payload
-):
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        with pytest.raises(
-            ValueError,
-            match=r"A 'body' parameter must be provided as a dictionary|'payload' needs to be a dictionary",
-        ):
-            client.create_standalone_connector(body=None, payload=invalid_payload)
-
-        assert any(
-            issubclass(warning.category, DeprecationWarning)
-            and "payload is deprecated" in str(warning.message)
-            for warning in w
-        ), "A DeprecationWarning for 'payload' should have been raised."
 
 
 @pytest.mark.skipif(

--- a/tests/ml_commons/test_model_connector.py
+++ b/tests/ml_commons/test_model_connector.py
@@ -77,7 +77,7 @@ def test_create_standalone_connector(client: Connector, connector_body: dict):
 
 @pytest.mark.parametrize("invalid_body", ["", None, [], 123])
 def test_create_standalone_connector_invalid_body(client: Connector, invalid_body):
-    with pytest.raises(ValueError, match="'body' must be a dictionary"):
+    with pytest.raises(ValueError, match="'body' needs to be a dictionary"):
         client.create_standalone_connector(body=invalid_body)
 
 
@@ -87,7 +87,7 @@ def test_create_standalone_connector_invalid_payload(
 ):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        with pytest.raises(ValueError, match="'payload' must be a dictionary"):
+        with pytest.raises(ValueError, match="'payload' needs to be a dictionary"):
             client.create_standalone_connector(payload=invalid_payload)
         assert any(
             issubclass(warning.category, DeprecationWarning)


### PR DESCRIPTION
### Description
- Updated `create_standalone_connector` to use `body` instead of `payload` as the primary argument for the JSON data.
- Added deprecation warning for `payload`, encouraging users to transition to `body`.
- Improved error handling to ensure `body` is provided as a dictionary.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-py-ml/issues/397
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
