### PR TITLE
Implement `predict` method and add unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Support for security default admin credential changes in 2.12.0 in ([#365](https://github.com/opensearch-project/opensearch-py-ml/pull/365))
 - adding cross encoder models in the pre-trained traced list ([#378](https://github.com/opensearch-project/opensearch-py-ml/pull/378))
 - Add workflows and scripts for sparse encoding model tracing and uploading process by @conggguan in ([#394](https://github.com/opensearch-project/opensearch-py-ml/pull/394))
+- Implemented `predict` method and added unit tests by @yerzhaisang([425](https://github.com/opensearch-project/opensearch-py-ml/pull/425))
 
 ### Changed
 - Add a parameter for customize the upload folder prefix ([#398](https://github.com/opensearch-project/opensearch-py-ml/pull/398))

--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -567,6 +567,36 @@ class MLCommonClient:
             url=API_URL,
             body=API_BODY,
         )
+    
+    def predict(
+        self, 
+        algorithm_name: str, 
+        model_id: str, 
+        predict_object: dict
+    ) -> dict:
+        """
+        Generalized predict method to make predictions using different ML algorithms.
+
+        :param algorithm_name: The name of the algorithm, e.g., 'kmeans', 'text_embedding'
+        :type algorithm_name: str
+        :param model_id: Unique identifier of the deployed model
+        :type model_id: str
+        :param predict_object: JSON object containing the input data and parameters for prediction
+        :type predict_object: dict
+        :return: Prediction response from the ML model
+        :rtype: dict
+        """
+        # Construct the URL for the prediction request
+        url = f"{ML_BASE_URI}/_predict/{algorithm_name}/{model_id}"
+        
+        # Make the POST request to the prediction API
+        response = self._client.transport.perform_request(
+            method="POST",
+            url=url,
+            body=predict_object
+        )
+
+        return response
 
     def undeploy_model(self, model_id: str, node_ids: List[str] = []) -> object:
         """

--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -567,13 +567,8 @@ class MLCommonClient:
             url=API_URL,
             body=API_BODY,
         )
-    
-    def predict(
-        self, 
-        algorithm_name: str, 
-        model_id: str, 
-        predict_object: dict
-    ) -> dict:
+
+    def predict(self, algorithm_name: str, model_id: str, predict_object: dict) -> dict:
         """
         Generalized predict method to make predictions using different ML algorithms.
 
@@ -588,12 +583,10 @@ class MLCommonClient:
         """
         # Construct the URL for the prediction request
         url = f"{ML_BASE_URI}/_predict/{algorithm_name}/{model_id}"
-        
+
         # Make the POST request to the prediction API
         response = self._client.transport.perform_request(
-            method="POST",
-            url=url,
-            body=predict_object
+            method="POST", url=url, body=predict_object
         )
 
         return response

--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -568,7 +568,9 @@ class MLCommonClient:
             body=API_BODY,
         )
 
-    def predict(self, algorithm_name: str, model_id: str, predict_object: dict) -> dict:
+    def predict(
+        self, model_id: str, predict_object: dict, algorithm_name: str = None
+    ) -> dict:
         """
         Generalized predict method to make predictions using different ML algorithms.
 

--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -581,13 +581,8 @@ class MLCommonClient:
         :return: Prediction response from the ML model
         :rtype: dict
         """
-        # Construct the URL for the prediction request
-        url = f"{ML_BASE_URI}/_predict/{algorithm_name}/{model_id}"
-
         # Make the POST request to the prediction API
-        response = self._client.transport.perform_request(
-            method="POST", url=url, body=predict_object
-        )
+        response = self.generate_model_inference(model_id, predict_object)
 
         return response
 

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -370,12 +370,21 @@ def test_DEPRECATED_integration_model_train_upload_full_cycle():
                             "target_response": target_response,
                         },
                     )
+                    prediction_result_2 = ml_client.generate_model_inference(
+                        model_id=model_id,
+                        predict_object={
+                            "text_docs": text_docs,
+                            "return_number": return_number,
+                            "target_response": target_response,
+                        },
+                    )
                     inference_results = prediction_result.get("inference_results")
                     output_1 = inference_results[0].get("output")
                     output_2 = inference_results[1].get("output")
                 except Exception as ex:  # noqa: E722
                     pytest.fail(f"Exception occurred when predicting: {ex}")
                 else:
+                    assert prediction_result == prediction_result_2
                     assert output_1[0].get("name") == "sentence_embedding"
                     assert output_1[0].get("data_type") == "FLOAT32"
                     assert output_1[0].get("shape")[0] == 384
@@ -514,12 +523,21 @@ def test_integration_model_train_register_full_cycle():
                             "target_response": target_response,
                         },
                     )
+                    prediction_result_2 = ml_client.generate_model_inference(
+                        model_id=model_id,
+                        predict_object={
+                            "text_docs": text_docs,
+                            "return_number": return_number,
+                            "target_response": target_response,
+                        },
+                    )
                     inference_results = prediction_result.get("inference_results")
                     output_1 = inference_results[0].get("output")
                     output_2 = inference_results[1].get("output")
                 except Exception as ex:  # noqa: E722
                     pytest.fail(f"Exception occurred when predicting: {ex}")
                 else:
+                    assert prediction_result == prediction_result_2
                     assert output_1[0].get("name") == "sentence_embedding"
                     assert output_1[0].get("data_type") == "FLOAT32"
                     assert output_1[0].get("shape")[0] == 384

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -357,6 +357,35 @@ def test_DEPRECATED_integration_model_train_upload_full_cycle():
                     assert len(embedding_result.get("inference_results")) == 2
 
                 try:
+                    text_docs = ["First test sentence", "Second test sentence"]
+                    return_number = True
+                    target_response = ["sentence_embedding"]
+                    algorithm_name = "text_embedding"
+                    prediction_result = ml_client.predict(
+                        algorithm_name=algorithm_name,
+                        model_id=model_id,
+                        predict_object={
+                            "text_docs": text_docs,
+                            "return_number": return_number,
+                            "target_response": target_response,
+                        },
+                    )
+                    inference_results = prediction_result.get("inference_results")
+                    output_1 = inference_results[0].get("output")
+                    output_2 = inference_results[1].get("output")
+                except Exception as ex:  # noqa: E722
+                    pytest.fail(f"Exception occurred when predicting: {ex}")
+                else:
+                    assert output_1[0].get("name") == "sentence_embedding"
+                    assert output_1[0].get("data_type") == "FLOAT32"
+                    assert output_1[0].get("shape")[0] == 384
+                    assert isinstance(output_1[0].get("data"), list)
+                    assert output_2[0].get("name") == "sentence_embedding"
+                    assert output_2[0].get("data_type") == "FLOAT32"
+                    assert output_2[0].get("shape")[0] == 384
+                    assert isinstance(output_2[0].get("data"), list)
+
+                try:
                     delete_task_obj = ml_client.delete_task(task_id)
                 except Exception as ex:  # noqa: E722
                     pytest.fail(f"Exception occurred when deleting task: {ex}")
@@ -470,6 +499,35 @@ def test_integration_model_train_register_full_cycle():
                     )
                 else:
                     assert len(embedding_result.get("inference_results")) == 2
+
+                try:
+                    text_docs = ["First test sentence", "Second test sentence"]
+                    return_number = True
+                    target_response = ["sentence_embedding"]
+                    algorithm_name = "text_embedding"
+                    prediction_result = ml_client.predict(
+                        algorithm_name=algorithm_name,
+                        model_id=model_id,
+                        predict_object={
+                            "text_docs": text_docs,
+                            "return_number": return_number,
+                            "target_response": target_response,
+                        },
+                    )
+                    inference_results = prediction_result.get("inference_results")
+                    output_1 = inference_results[0].get("output")
+                    output_2 = inference_results[1].get("output")
+                except Exception as ex:  # noqa: E722
+                    pytest.fail(f"Exception occurred when predicting: {ex}")
+                else:
+                    assert output_1[0].get("name") == "sentence_embedding"
+                    assert output_1[0].get("data_type") == "FLOAT32"
+                    assert output_1[0].get("shape")[0] == 384
+                    assert isinstance(output_1[0].get("data"), list)
+                    assert output_2[0].get("name") == "sentence_embedding"
+                    assert output_2[0].get("data_type") == "FLOAT32"
+                    assert output_2[0].get("shape")[0] == 384
+                    assert isinstance(output_2[0].get("data"), list)
 
                 try:
                     delete_task_obj = ml_client.delete_task(task_id)


### PR DESCRIPTION
### Description
- Implemented the `predict` method in `MLCommonClient`.
- Added unit tests to ensure the correctness of the `predict` method's behavior.
- Integrated the method with the existing system and ensured it handles the parameters (`text_docs`, `return_number`, `target_response`) as expected.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-py-ml/issues/287
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
