### PR TITLE
Update GitHub Actions to use @v4 to prevent deprecation issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,14 @@
+version: 2
 updates:
-  - directory: /
-    open-pull-requests-limit: 3
-    package-ecosystem: pip
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
+    open-pull-requests-limit: 3
     labels:
       - "dependabot"
       - "dependencies"
-version: 2
-updates:
+      
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
       - "dependabot"
       - "dependencies"
 version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: pip
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
     open-pull-requests-limit: 3
     labels:
       - "dependabot"
@@ -12,4 +12,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly

--- a/.github/workflows/build_deploy_doc.yml
+++ b/.github/workflows/build_deploy_doc.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Integ ${{ matrix.cluster }} secured=${{ matrix.secured }} version=${{matrix.entry.opensearch_version}}
         run: "./.ci/run-tests ${{ matrix.cluster }} ${{ matrix.secured }} ${{ matrix.entry.opensearch_version }} doc"
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/build/html

--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -13,6 +13,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: dangoslen/changelog-enforcer@v4
+      - uses: dangoslen/changelog-enforcer@v3
         with:
           skipLabels: "autocut, skip-changelog"

--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -8,11 +8,11 @@ jobs:
   verify-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: dangoslen/changelog-enforcer@v3
+      - uses: dangoslen/changelog-enforcer@v4
         with:
           skipLabels: "autocut, skip-changelog"

--- a/.github/workflows/delete_model_uploader_branch.yml
+++ b/.github/workflows/delete_model_uploader_branch.yml
@@ -12,7 +12,7 @@ jobs:
       # Compared to backport.yml, this GitHub action will delete branch
       # of a PR that is closed, but not merged as well.
       - name: Delete closed PR branch
-        uses: dawidd6/action-delete-branch@v3
+        uses: dawidd6/action-delete-branch@v4
         with:
           GITHUB_TOKEN: ${{github.token}}
           numbers: ${{github.event.pull_request.number}}

--- a/.github/workflows/model_listing_uploader.yml
+++ b/.github/workflows/model_listing_uploader.yml
@@ -23,7 +23,7 @@ jobs:
          echo "This workflow should only be triggered on 'main' branch"
          exit 1
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v2
       with:
@@ -40,7 +40,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Trigger Jenkins Workflow with Generic Webhook
         run: |
           jenkins_trigger_token=${{ secrets.JENKINS_ML_MODELS_RELEASE_GENERIC_WEBHOOK_TOKEN }}

--- a/.github/workflows/model_uploader.yml
+++ b/.github/workflows/model_uploader.yml
@@ -146,7 +146,7 @@ jobs:
     environment: opensearch-py-ml-cicd-env
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set Up Python
         uses: actions/setup-python@v2
         with:
@@ -199,7 +199,7 @@ jobs:
           - { opensearch_version: 2.11.0 }
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Export Arguments
         run: | 
           echo "MODEL_ID=${{ github.event.inputs.model_id }}" >> $GITHUB_ENV
@@ -240,7 +240,7 @@ jobs:
           echo "model_description_info=- Model Description: $model_description_info" >> $GITHUB_OUTPUT
           echo "$model_description_info"
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: 
           name: upload
           path: ./upload/
@@ -276,7 +276,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get Approvers
         id: get_approvers
         run: |
@@ -347,7 +347,7 @@ jobs:
       model_info: ${{ github.event.inputs.model_id }} (v.${{ github.event.inputs.model_version }})(${{ github.event.inputs.tracing_format }})
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set Up Python
         uses: actions/setup-python@v2
         with:
@@ -398,7 +398,7 @@ jobs:
             ./utils/model_uploader/upload_history/MODEL_UPLOAD_HISTORY.md
             ./utils/model_uploader/upload_history/supported_models.json
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: model-uploader/${{ github.run_id }}
       - name: Create a line for updating CHANGELOG.md
@@ -449,7 +449,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Trigger Jenkins Workflow with Generic Webhook
         run: |
           jenkins_trigger_token=${{ secrets.JENKINS_ML_MODELS_RELEASE_GENERIC_WEBHOOK_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: get_approvers
         run: |
           echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
@@ -27,7 +27,7 @@ jobs:
           issue-body: "Please approve or deny the release of opensearch-py-ml. **Tag**: ${{ github.ref_name }}  **Commit**: ${{ github.sha }}"
           exclude-workflow-initiator-as-approver: true
       - name: Set up Python 3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - name: Install build tools

--- a/.github/workflows/update_model_listing.yml
+++ b/.github/workflows/update_model_listing.yml
@@ -22,7 +22,7 @@ jobs:
          echo "This workflow should only be triggered on 'main' branch"
          exit 1
     - name: Checkout Main Branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v2
       with:
@@ -94,7 +94,7 @@ jobs:
     - name: Checkout PR Branch
       id: checkout_pr_branch
       continue-on-error: true
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: model-listing-uploader/${{ github.run_id }}
     - name: Create a line for updating CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - updating listing file with three v2 sparse model - by @dhrubo-os ([#412](https://github.com/opensearch-project/opensearch-py-ml/pull/412))
 - Update model upload history -  opensearch-project/opensearch-neural-sparse-encoding-doc-v2-mini (v.1.0.0)(TORCH_SCRIPT) by @dhrubo-os ([#417](https://github.com/opensearch-project/opensearch-py-ml/pull/417))
 - Update model upload history -  opensearch-project/opensearch-neural-sparse-encoding-v2-distill (v.1.0.0)(TORCH_SCRIPT) by @dhrubo-os ([#419](https://github.com/opensearch-project/opensearch-py-ml/pull/419))
+- Upgrade GitHub Actions workflows to use `@v4` to prevent deprecation issues with `@v3` by @yerzhaisang ([#428](https://github.com/opensearch-project/opensearch-py-ml/pull/428))
 
 ### Fixed
 - Fix the wrong final zip file name in model_uploader workflow, now will name it by the upload_prefix alse.([#413](https://github.com/opensearch-project/opensearch-py-ml/pull/413/files))


### PR DESCRIPTION
### Description
- Updated all workflow files to replace @v3 with @v4
- Ensured artifact actions comply with GitHub's deprecation policy
- Added Dependabot configuration for automatic GitHub Actions updates
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-py-ml/issues/426
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
