### PR TITLE
Fix integ test flaky test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - fix CVE vulnerability by @rawwar in ([#383](https://github.com/opensearch-project/opensearch-py-ml/pull/383))
 - refactor: replace 'payload' with 'body' in `create_standalone_connector` by @yerzhaisang ([#424](https://github.com/opensearch-project/opensearch-py-ml/pull/424))
 - Fix CVE vulnerability by @nathaliellenaa in ([#447](https://github.com/opensearch-project/opensearch-py-ml/pull/447))
+- Use one model id for sparse model integ test to reduce flaky error caused by throttling ([#475](https://github.com/opensearch-project/opensearch-py-ml/pull/475))
 
 ## [1.1.0]
 

--- a/tests/ml_models/test_sparse_tokenize_model_pytest.py
+++ b/tests/ml_models/test_sparse_tokenize_model_pytest.py
@@ -56,11 +56,11 @@ def test_check_attribute():
     clean_test_folder(TEST_FOLDER)
     test_model1 = SparseTokenizeModel(
         folder_path=TEST_FOLDER,
-        model_id="opensearch-project/opensearch-neural-sparse-encoding-doc-v3-distill",
+        model_id="opensearch-project/opensearch-neural-sparse-encoding-doc-v2-distill",
     )
     assert (
         test_model1.model_id
-        == "opensearch-project/opensearch-neural-sparse-encoding-doc-v3-distill"
+        == "opensearch-project/opensearch-neural-sparse-encoding-doc-v2-distill"
     )
 
 
@@ -92,7 +92,7 @@ def test_save_as_pt():
 def test_make_model_config_json_for_torch_script():
     model_format = "TORCH_SCRIPT"
     expected_model_description = "This is a sparse encoding model for opensearch-neural-sparse-encoding-doc-v3-distill."
-    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v3-distill"
+    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v2-distill"
     clean_test_folder(TEST_FOLDER)
     test_model3 = SparseTokenizeModel(model_id=model_id, folder_path=TEST_FOLDER)
     test_model3.save_as_pt(model_id=model_id, sentences=["today is sunny"])
@@ -112,7 +112,7 @@ def test_make_model_config_json_for_torch_script():
 
 
 def test_overwrite_description():
-    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v3-distill"
+    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v2-distill"
     model_format = "TORCH_SCRIPT"
     expected_model_description = "Expected Description"
 
@@ -143,7 +143,7 @@ def test_overwrite_description():
 
 
 def test_long_description():
-    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v3-distill"
+    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v2-distill"
     model_format = "TORCH_SCRIPT"
     expected_model_description = (
         "This is a sparce encoding model: It generate lots of tokens with different weight "
@@ -178,10 +178,10 @@ def test_long_description():
 
 
 def test_save_as_pt_with_license():
-    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v3-distill"
+    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v2-distill"
     model_format = "TORCH_SCRIPT"
     torch_script_zip_file_path = os.path.join(
-        TEST_FOLDER, "opensearch-neural-sparse-encoding-doc-v3-distill.zip"
+        TEST_FOLDER, "opensearch-neural-sparse-encoding-doc-v2-distill.zip"
     )
     torch_script_expected_filenames = {
         "idf.json",
@@ -207,7 +207,7 @@ def test_save_as_pt_with_license():
 
 
 def test_default_description():
-    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v3-distill"
+    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v2-distill"
     model_format = "TORCH_SCRIPT"
     expected_model_description = "This is a neural sparse tokenizer model: It tokenize input sentence into tokens and assign pre-defined weight from IDF to each. It serves only in query."
 
@@ -238,7 +238,7 @@ def test_default_description():
 
 
 def test_process_sparse_encoding():
-    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v3-distill"
+    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v2-distill"
 
     test_model8 = SparseTokenizeModel(
         folder_path=TEST_FOLDER,
@@ -252,7 +252,7 @@ def test_process_sparse_encoding():
 
 
 def test_save():
-    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v3-distill"
+    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v2-distill"
 
     test_model9 = SparseTokenizeModel(
         folder_path=TEST_FOLDER,

--- a/tests/ml_models/test_sparseencondingmodel_pytest.py
+++ b/tests/ml_models/test_sparseencondingmodel_pytest.py
@@ -278,7 +278,7 @@ def test_save_as_pt_with_license():
 
 
 def test_default_description():
-    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v3-distill"
+    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v2-distill"
     model_format = "TORCH_SCRIPT"
     expected_model_description = "This is a neural sparse encoding model: It transfers text into sparse vector, and then extract nonzero index and value to entry and weights. It serves only in ingestion and customer should use tokenizer model in query."
 
@@ -309,7 +309,7 @@ def test_default_description():
 
 
 def test_process_sparse_encoding():
-    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v3-distill"
+    model_id = "opensearch-project/opensearch-neural-sparse-encoding-doc-v2-distill"
 
     test_model8 = SparseEncodingModel(
         folder_path=TEST_FOLDER,
@@ -317,10 +317,10 @@ def test_process_sparse_encoding():
     )
 
     encoding_result = test_model8.process_sparse_encoding(["hello world", "hello"])
-    assert len(encoding_result[0]) == 73
-    check_value(1.3667216300964355, encoding_result[0]["hello"], 0.001)
-    assert len(encoding_result[1]) == 46
-    check_value(1.4557286500930786, encoding_result[1]["hello"], 0.001)
+    assert len(encoding_result[0]) == 298
+    check_value(1.6551653146743774, encoding_result[0]["hello"], 0.001)
+    assert len(encoding_result[1]) == 260
+    check_value(1.9172965288162231, encoding_result[1]["hello"], 0.001)
 
     test_model8 = SparseEncodingModel(
         folder_path=TEST_FOLDER,
@@ -329,10 +329,10 @@ def test_process_sparse_encoding():
         activation="l0",
     )
     encoding_result = test_model8.process_sparse_encoding(["hello world", "hello"])
-    assert len(encoding_result[0]) == 33
-    check_value(0.8615057468414307, encoding_result[0]["hello"], 0.001)
-    assert len(encoding_result[1]) == 30
-    check_value(0.8984234929084778, encoding_result[1]["hello"], 0.001)
+    assert len(encoding_result[0]) == 77
+    check_value(0.9765068888664246, encoding_result[0]["hello"], 0.001)
+    assert len(encoding_result[1]) == 64
+    check_value(1.0706572532653809, encoding_result[1]["hello"], 0.001)
 
 
 clean_test_folder(TEST_FOLDER)


### PR DESCRIPTION
### Description
We see integ test failing https://github.com/opensearch-project/opensearch-py-ml/actions/runs/14520924174/job/40742876990, and the error message is 
```
E           huggingface_hub.errors.HfHubHTTPError: 429 Client Error: Too Many Requests for url: https://huggingface.co/opensearch-project/opensearch-neural-sparse-encoding-doc-v3-distill/resolve/main/config.json
```

The error is caused by huggingface throttling. This PR makes all sparse model tests use one model id, therefore we can reuse the model file in cache, to reduce the probability of flaky test.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
