### PR TITLE
Fix sparse model upload workflow cased by SDPA exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - refactor: replace 'payload' with 'body' in `create_standalone_connector` by @yerzhaisang ([#424](https://github.com/opensearch-project/opensearch-py-ml/pull/424))
 - Fix CVE vulnerability by @nathaliellenaa in ([#447](https://github.com/opensearch-project/opensearch-py-ml/pull/447))
 - Use one model id for sparse model integ test to reduce flaky error caused by throttling ([#475](https://github.com/opensearch-project/opensearch-py-ml/pull/475))
+- Fix sparse upload workflow caused by SDPA exception ([#478](https://github.com/opensearch-project/opensearch-py-ml/pull/478))
 
 ## [1.1.0]
 

--- a/opensearch_py_ml/ml_models/sparse_encoding_model.py
+++ b/opensearch_py_ml/ml_models/sparse_encoding_model.py
@@ -54,7 +54,9 @@ class SparseEncodingModel(SparseModel):
 
         super().__init__(model_id, folder_path, overwrite)
         self.tokenizer = AutoTokenizer.from_pretrained(model_id)
-        self.backbone_model = AutoModelForMaskedLM.from_pretrained(model_id)
+        self.backbone_model = AutoModelForMaskedLM.from_pretrained(
+            model_id, _attn_implementation="eager"
+        )
         default_folder_path = os.path.join(
             os.getcwd(), "opensearch_neural_sparse_model_files"
         )
@@ -247,7 +249,10 @@ class SparseEncodingModel(SparseModel):
         if self.backbone_model is not None:
             return self.backbone_model
         else:
-            return AutoModelForMaskedLM.from_pretrained(self.model_id)
+            # spda attention is not supported by OpenSearch djl version
+            return AutoModelForMaskedLM.from_pretrained(
+                self.model_id, _attn_implementation="eager"
+            )
 
     def get_model(self):
         return NeuralSparseModel(

--- a/utils/model_uploader/autotracing_utils.py
+++ b/utils/model_uploader/autotracing_utils.py
@@ -112,6 +112,7 @@ def undeploy_model(
 
     """
     try:
+        ml_model_status = {}
         ml_client.undeploy_model(model_id)
         ml_model_status = ml_client.get_model_info(model_id)
         assert ml_model_status.get("model_state") == "UNDEPLOYED"
@@ -139,6 +140,7 @@ def delete_model(
 
     """
     try:
+        delete_model_obj = {}
         delete_model_obj = ml_client.delete_model(model_id)
         assert delete_model_obj.get("result") == "deleted"
     except Exception as e:

--- a/utils/model_uploader/autotracing_utils.py
+++ b/utils/model_uploader/autotracing_utils.py
@@ -112,7 +112,6 @@ def undeploy_model(
 
     """
     try:
-        ml_model_status = {}
         ml_client.undeploy_model(model_id)
         ml_model_status = ml_client.get_model_info(model_id)
         assert ml_model_status.get("model_state") == "UNDEPLOYED"
@@ -120,9 +119,7 @@ def undeploy_model(
         if throw_exception:
             assert False, f"Raised Exception in {model_format} model undeployment: {e}"
         else:
-            print(
-                f"Failed to undeploy model. model status: {ml_model_status.get('model_state')}"
-            )
+            print(f"Raised Exception in {model_format} model undeployment: {e}")
 
 
 def delete_model(
@@ -140,16 +137,13 @@ def delete_model(
 
     """
     try:
-        delete_model_obj = {}
         delete_model_obj = ml_client.delete_model(model_id)
         assert delete_model_obj.get("result") == "deleted"
     except Exception as e:
         if throw_exception:
             assert False, f"Raised Exception in deleting {model_format} model: {e}"
         else:
-            print(
-                f"Failed to delete model. model status: {delete_model_obj.get('result')}"
-            )
+            print(f"Raised Exception in deleting {model_format} model: {e}")
 
 
 def autotracing_warning_filters():


### PR DESCRIPTION
### Description
When using current code to trace sparse models and deploy them in OpenSearch, we get exceptions like this:
```
  File "code/__torch__/transformers/models/bert/modeling_bert.py", line 196
    x1 = torch.view(_40, [_42, int(_43), 12, 64])
    value_layer = torch.permute(x1, [0, 2, 1, 3])
    attn_output = torch.scaled_dot_product_attention(query_layer, key_layer, value_layer, attention_mask)
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
    attn_output0 = torch.transpose(attn_output, 1, 2)
    input = torch.reshape(attn_output0, [_30, _31, 768])
```

That is because transformers introduce SDPA attention from v4.41.0, and the scaled_dot_product_attention is not supported by OpenSearch DJL.

This PR overwrite the attention implementation to normal BertSelfAttention. So that we don't need SDPA in djl.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
