### PR TITLE
Fix hardcoded port number in OpenSearch client initialization in CLI

### DIFF
--- a/opensearch_py_ml/ml_commons/cli/ai_connector_helper.py
+++ b/opensearch_py_ml/ml_commons/cli/ai_connector_helper.py
@@ -40,7 +40,6 @@ class AIConnectorHelper:
 
     OPEN_SOURCE = "open-source"
     AMAZON_OPENSEARCH_SERVICE = "amazon-opensearch-service"
-    AWS_DOMAIN = "amazonaws.com"
 
     def __init__(
         self,
@@ -77,15 +76,12 @@ class AIConnectorHelper:
             )
         self.opensearch_domain_arn = domain_arn
 
-        # Parse the OpenSearch domain URL to extract host and port
+        # Parse the OpenSearch domain URL
         parsed_url = urlparse(self.opensearch_config.opensearch_domain_endpoint)
-        host = parsed_url.hostname
-        is_aos = self.AWS_DOMAIN in host
-        port = parsed_url.port or (443 if is_aos else 9200)
 
         # Initialize OpenSearch client
         self.opensearch_client = OpenSearch(
-            hosts=[{"host": host, "port": port}],
+            hosts=[self.opensearch_config.opensearch_domain_endpoint],
             http_auth=(
                 self.opensearch_config.opensearch_domain_username,
                 self.opensearch_config.opensearch_domain_password,

--- a/opensearch_py_ml/ml_commons/cli/ml_setup.py
+++ b/opensearch_py_ml/ml_commons/cli/ml_setup.py
@@ -439,9 +439,7 @@ class Setup(CLIBase):
             return False
 
         parsed_url = urlparse(self.opensearch_config.opensearch_domain_endpoint)
-        host = parsed_url.hostname
-        is_aos = "amazonaws.com" in host
-        port = parsed_url.port or (443 if is_aos else 9200)
+
         # Determine auth based on service type
         if self.service_type == self.AMAZON_OPENSEARCH_SERVICE:
             if (
@@ -471,20 +469,18 @@ class Setup(CLIBase):
             logger.warning("Invalid service type. Please check your configuration.")
             return False
 
-        use_ssl = parsed_url.scheme == "https"
-
         try:
             self.opensearch_client = OpenSearch(
-                hosts=[{"host": host, "port": port}],
+                hosts=[self.opensearch_config.opensearch_domain_endpoint],
                 http_auth=auth,
-                use_ssl=use_ssl,
+                use_ssl=(parsed_url.scheme == "https"),
                 verify_certs=self.ssl_check_enabled,
                 ssl_show_warn=False,
                 connection_class=RequestsHttpConnection,
                 pool_maxsize=20,
             )
             print(
-                f"{Fore.GREEN}Initialized OpenSearch client with host: {host} and port: {port}{Style.RESET_ALL}\n"
+                f"{Fore.GREEN}Initialized OpenSearch client with endpoint: {self.opensearch_config.opensearch_domain_endpoint}{Style.RESET_ALL}\n"
             )
             return True
         except Exception as e:

--- a/tests/cli/test_ai_connector_helper.py
+++ b/tests/cli/test_ai_connector_helper.py
@@ -89,10 +89,6 @@ class TestAIConnectorHelper(unittest.TestCase):
 
         # Parse the URL
         parsed_url = urlparse(self.opensearch_config.opensearch_domain_endpoint)
-        expected_host = parsed_url.hostname
-        is_aos = "amazonaws.com" in expected_host
-        expected_port = parsed_url.port or (443 if is_aos else 9200)
-        expected_use_ssl = parsed_url.scheme == "https"
 
         # Instantiate AIConnectorHelper
         helper = AIConnectorHelper(
@@ -112,12 +108,12 @@ class TestAIConnectorHelper(unittest.TestCase):
 
         # Assert OpenSearch client initialization
         self.mock_opensearch.assert_called_once_with(
-            hosts=[{"host": expected_host, "port": expected_port}],
+            hosts=[self.opensearch_config.opensearch_domain_endpoint],
             http_auth=(
                 self.opensearch_config.opensearch_domain_username,
                 self.opensearch_config.opensearch_domain_password,
             ),
-            use_ssl=expected_use_ssl,
+            use_ssl=(parsed_url.scheme == "https"),
             verify_certs=self.ssl_check_enabled,
             connection_class=RequestsHttpConnection,
         )


### PR DESCRIPTION
### Description
Fix hardcoded port number in OpenSearch client initialization in the CLI
 
### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-py-ml/issues/500
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
