### PR TITLE
Add space type mapping for sentence transformer models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add semantic highlighter model to pre-trained model list ([#504](https://github.com/opensearch-project/opensearch-py-ml/pull/504))
 - Fix jenkins token in model_listing_uploader.yml CI ([#505](https://github.com/opensearch-project/opensearch-py-ml/pull/505))
 - Add documentation for CLI feature by @nathaliellenaa in ([#476](https://github.com/opensearch-project/opensearch-py-ml/pull/476))
+- Add space type mapping for sentence transformer models by @nathaliellenaa in ([#512](https://github.com/opensearch-project/opensearch-py-ml/pull/512))
 
 ### Changed
 - Add a parameter for customize the upload folder prefix ([#398](https://github.com/opensearch-project/opensearch-py-ml/pull/398))

--- a/opensearch_py_ml/ml_models/sentencetransformermodel.py
+++ b/opensearch_py_ml/ml_models/sentencetransformermodel.py
@@ -53,6 +53,20 @@ class SentenceTransformerModel(BaseUploadModel):
     DEFAULT_MODEL_ID = "sentence-transformers/msmarco-distilbert-base-tas-b"
     SYNTHETIC_QUERY_FOLDER = "synthetic_queries"
 
+    MODEL_SPACE_TYPE_MAPPING = {
+        "all-distilroberta-v1": "l2",
+        "all-MiniLM-L6-v2": "l2",
+        "all-MiniLM-L12-v2": "l2",
+        "all-mpnet-base-v2": "l2",
+        "msmarco-distilbert-base-tas-b": "innerproduct",
+        "multi-qa-MiniLM-L6-cos-v1": "l2",
+        "multi-qa-mpnet-base-dot-v1": "innerproduct",
+        "paraphrase-MiniLM-L3-v2": "cosine",
+        "paraphrase-multilingual-MiniLM-L12-v2": "cosine",
+        "paraphrase-mpnet-base-v2": "cosine",
+        "distiluse-base-multilingual-cased-v1": "cosine",
+    }
+
     def __init__(
         self,
         model_id: str = DEFAULT_MODEL_ID,
@@ -1277,6 +1291,7 @@ class SentenceTransformerModel(BaseUploadModel):
         normalize_result: bool = None,
         description: str = None,
         all_config: str = None,
+        additional_config: dict = None,
         model_type: str = None,
         verbose: bool = False,
     ) -> str:
@@ -1314,7 +1329,10 @@ class SentenceTransformerModel(BaseUploadModel):
         :param all_config:
             Optional, the all_config of the model. If None, parse all contents from the config file of pre-trained
             hugging-face model
-        :type all_config: dict
+        :type all_config: str
+        :param additional_config:
+            Optional, the additional_config of the model. If None, set additional_config as an empty dictionary
+        :type additional_config: dict
         :param model_type:
             Optional, the model_type of the model. If None, parse model_type from the config file of pre-trained
             hugging-face model
@@ -1401,6 +1419,15 @@ class SentenceTransformerModel(BaseUploadModel):
                     ". Please check the config.json ",
                     "file in the path.",
                 )
+        if additional_config is None:
+            additional_config = {}
+        if (
+            "space_type" not in additional_config
+            or additional_config.get("space_type") is None
+        ):
+            model_name_suffix = self.model_id.split("/")[-1]
+            space_type = self.MODEL_SPACE_TYPE_MAPPING.get(model_name_suffix, "l2")
+            additional_config["space_type"] = space_type
 
         model_config_content = {
             "name": model_name,
@@ -1415,6 +1442,7 @@ class SentenceTransformerModel(BaseUploadModel):
                 "pooling_mode": pooling_mode,
                 "normalize_result": normalize_result,
                 "all_config": json.dumps(all_config),
+                "additional_config": additional_config,
             },
         }
 

--- a/opensearch_py_ml/ml_models/sentencetransformermodel.py
+++ b/opensearch_py_ml/ml_models/sentencetransformermodel.py
@@ -1421,13 +1421,15 @@ class SentenceTransformerModel(BaseUploadModel):
                 )
         if additional_config is None:
             additional_config = {}
-        if (
-            "space_type" not in additional_config
-            or additional_config.get("space_type") is None
-        ):
+        if not additional_config.get("space_type"):
             model_name_suffix = self.model_id.split("/")[-1]
-            space_type = self.MODEL_SPACE_TYPE_MAPPING.get(model_name_suffix, "l2")
-            additional_config["space_type"] = space_type
+            if model_name_suffix not in self.MODEL_SPACE_TYPE_MAPPING:
+                print(
+                    f"Default space type cannot be determined for model '{model_name_suffix}'. Consider adding space_type in additional_config."
+                )
+            else:
+                space_type = self.MODEL_SPACE_TYPE_MAPPING[model_name_suffix]
+                additional_config["space_type"] = space_type
 
         model_config_content = {
             "name": model_name,
@@ -1442,9 +1444,12 @@ class SentenceTransformerModel(BaseUploadModel):
                 "pooling_mode": pooling_mode,
                 "normalize_result": normalize_result,
                 "all_config": json.dumps(all_config),
-                "additional_config": additional_config,
             },
         }
+        if additional_config:
+            model_config_content["model_config"][
+                "additional_config"
+            ] = additional_config
 
         if model_zip_file_path is None:
             model_zip_file_path = (

--- a/tests/ml_models/test_sentencetransformermodel_pytest.py
+++ b/tests/ml_models/test_sentencetransformermodel_pytest.py
@@ -243,6 +243,7 @@ def test_make_model_config_json_for_torch_script():
         "embedding_dimension": 384,
         "pooling_mode": "MEAN",
         "normalize_result": True,
+        "additional_config": {"space_type": "l2"},
     }
 
     clean_test_folder(TEST_FOLDER)
@@ -275,6 +276,7 @@ def test_make_model_config_json_for_onnx():
         "embedding_dimension": 384,
         "pooling_mode": "MEAN",
         "normalize_result": False,
+        "additional_config": {"space_type": "cosine"},
     }
 
     clean_test_folder(TEST_FOLDER)
@@ -304,12 +306,14 @@ def test_overwrite_fields_in_model_config():
         "embedding_dimension": 768,
         "pooling_mode": "MEAN",
         "normalize_result": True,
+        "additional_config": {"space_type": "l2"},
     }
 
     overwritten_model_config_data = {
         "embedding_dimension": 128,
         "pooling_mode": "MAX",
         "normalize_result": False,
+        "additional_config": {"space_type": "cosine"},
     }
 
     clean_test_folder(TEST_FOLDER)
@@ -343,6 +347,7 @@ def test_overwrite_fields_in_model_config():
         embedding_dimension=overwritten_model_config_data["embedding_dimension"],
         pooling_mode=overwritten_model_config_data["pooling_mode"],
         normalize_result=overwritten_model_config_data["normalize_result"],
+        additional_config=overwritten_model_config_data["additional_config"],
     )
 
     compare_model_config(


### PR DESCRIPTION
### Description
Add space type mapping for sentence transformer models
 
### Issues Resolved
Related to https://github.com/opensearch-project/ml-commons/issues/3527
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
