### PR TITLE
[Enhancement] Pass model_init_kwargs to sparse model auto tracing to load remote model class

### DIFF
--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -77,21 +77,21 @@ elif [[ "$TASK_TYPE" == "SentenceTransformerTrace" || "$TASK_TYPE" == "SparseTra
   echo -e "\033[34;1mINFO:\033[0m ACTIVATION: ${ACTIVATION:-N/A}\033[0m"
   echo -e "\033[34;1mINFO:\033[0m MODEL_DESCRIPTION: ${MODEL_DESCRIPTION:-N/A}\033[0m"
   echo -e "\033[34;1mINFO:\033[0m MODEL_NAME: ${MODEL_NAME:-N/A}\033[0m"
-  echo -e "\033[34;1mINFO:\033[0m TRUST_REMOTE_CODE: ${TRUST_REMOTE_CODE:-N/A}\033[0m"
+  echo -e "\033[34;1mINFO:\033[0m MODEL_INIT_KWARGS: ${MODEL_INIT_KWARGS:-{}}\033[0m"
 
   if [[ "$TASK_TYPE" == "SentenceTransformerTrace" ]]; then
       NOX_TRACE_TYPE="trace"
-      EXTRA_ARGS="-ed ${EMBEDDING_DIMENSION} -pm ${POOLING_MODE}"
+      EXTRA_ARGS=( -ed "${EMBEDDING_DIMENSION}" -pm "${POOLING_MODE}" )
   elif [[ "$TASK_TYPE" == "SparseTrace" ]]; then
       NOX_TRACE_TYPE="sparsetrace"
-      EXTRA_ARGS="-spr ${SPARSE_PRUNE_RATIO} -act ${ACTIVATION} -trc ${TRUST_REMOTE_CODE}"
+      EXTRA_ARGS=( -spr "${SPARSE_PRUNE_RATIO}" -act "${ACTIVATION}" -mik "${MODEL_INIT_KWARGS}" )
   elif [[ "$TASK_TYPE" == "SparseTokenizerTrace" ]]; then
       NOX_TRACE_TYPE="sparsetrace"
-      # use extra args to trigger the tokenizer tracing logics
-      EXTRA_ARGS="-t"
+      # use extra args to trigger the tokenizer tracing logics (no -mik for tokenizer)
+      EXTRA_ARGS=( -t )
   elif [[ "$TASK_TYPE" == "SemanticHighlighterTrace" ]]; then
       NOX_TRACE_TYPE="semantic_highlighter_trace"
-      EXTRA_ARGS=""
+      EXTRA_ARGS=()
   else
       echo "Unknown TASK_TYPE: $TASK_TYPE"
       exit 1
@@ -106,7 +106,7 @@ elif [[ "$TASK_TYPE" == "SentenceTransformerTrace" || "$TASK_TYPE" == "SparseTra
     -up "${UPLOAD_PREFIX}"
     -mn "${MODEL_NAME}"
     -md "${MODEL_DESCRIPTION:+"$MODEL_DESCRIPTION"}"
-    ${EXTRA_ARGS}
+    "${EXTRA_ARGS[@]}"
   )
 
   echo "nox -s ${nox_command[@]}"

--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -77,13 +77,14 @@ elif [[ "$TASK_TYPE" == "SentenceTransformerTrace" || "$TASK_TYPE" == "SparseTra
   echo -e "\033[34;1mINFO:\033[0m ACTIVATION: ${ACTIVATION:-N/A}\033[0m"
   echo -e "\033[34;1mINFO:\033[0m MODEL_DESCRIPTION: ${MODEL_DESCRIPTION:-N/A}\033[0m"
   echo -e "\033[34;1mINFO:\033[0m MODEL_NAME: ${MODEL_NAME:-N/A}\033[0m"
+  echo -e "\033[34;1mINFO:\033[0m TRUST_REMOTE_CODE: ${TRUST_REMOTE_CODE:-N/A}\033[0m"
 
   if [[ "$TASK_TYPE" == "SentenceTransformerTrace" ]]; then
       NOX_TRACE_TYPE="trace"
       EXTRA_ARGS="-ed ${EMBEDDING_DIMENSION} -pm ${POOLING_MODE}"
   elif [[ "$TASK_TYPE" == "SparseTrace" ]]; then
       NOX_TRACE_TYPE="sparsetrace"
-      EXTRA_ARGS="-spr ${SPARSE_PRUNE_RATIO} -act ${ACTIVATION}"
+      EXTRA_ARGS="-spr ${SPARSE_PRUNE_RATIO} -act ${ACTIVATION} -trc ${TRUST_REMOTE_CODE}"
   elif [[ "$TASK_TYPE" == "SparseTokenizerTrace" ]]; then
       NOX_TRACE_TYPE="sparsetrace"
       # use extra args to trigger the tokenizer tracing logics

--- a/.github/workflows/model_uploader.yml
+++ b/.github/workflows/model_uploader.yml
@@ -67,7 +67,7 @@ on:
             "sparse_prune_ratio": (Optional) Float. Specifies the model-side prune ratio based on max values. Sparse model only.
             "activation": (Optional) String. Specifies the activation function for the sparse model. Sparse model only.
             "model_name": (Optional) String. Specifies the model name for uploading. Example: transforms "sentence-transformers/model" to "sentence-transformers/{model_name}",
-            "trust_remote_code": (Optional) Boolean. Specifies whether to trust remote model code.
+            "model_init_kwargs": (Optional) Object. JSON object to pass to from_pretrained via **kwargs.
           }
           
           Example:
@@ -103,27 +103,27 @@ jobs:
         sparse_prune_ratio=0
         activation=""
         model_name="${model_id##*/}"
-        trust_remote_code=false
+        model_init_kwargs="{}"
 
         if [ "$custom_params" != "{}" ] && [ -n "$custom_params" ]; then
           tmp_up=$(echo "$custom_params" | jq -r '.upload_prefix | select(.!=null)')
           tmp_spr=$(echo "$custom_params" | jq -r '.sparse_prune_ratio | select(.!=null)')
           tmp_act=$(echo "$custom_params" | jq -r '.activation | select(.!=null)')
           tmp_mn=$(echo "$custom_params" | jq -r '.model_name | select(.!=null)')
-          tmp_trc=$(echo "$custom_params" | jq -r '.trust_remote_code | select(.!=null)')
+          tmp_mik=$(echo "$custom_params" | jq -c '.model_init_kwargs | select(.!=null)')
 
           [ -n "$tmp_up" ] && upload_prefix="$tmp_up"
           [ -n "$tmp_spr" ] && sparse_prune_ratio="$tmp_spr"
           [ -n "$tmp_act" ] && activation="$tmp_act"
           [ -n "$tmp_mn" ] && model_name="$tmp_mn"
-          [ -n "$tmp_trc" ] && trust_remote_code="$tmp_trc"
+          [ -n "$tmp_mik" ] && model_init_kwargs="$tmp_mik"
         fi
 
         echo "upload_prefix=$upload_prefix" >> $GITHUB_OUTPUT
         echo "sparse_prune_ratio=$sparse_prune_ratio" >> $GITHUB_OUTPUT
         echo "activation=$activation" >> $GITHUB_OUTPUT
         echo "model_name=$model_name" >> $GITHUB_OUTPUT
-        echo "trust_remote_code=$trust_remote_code" >> $GITHUB_OUTPUT
+        echo "model_init_kwargs=$model_init_kwargs" >> $GITHUB_OUTPUT
     - name: Initiate folders
       # This scripts init the folders path variables.
       # 1. Retrieves the input model_id.
@@ -172,7 +172,7 @@ jobs:
         - Model Prefix Folder: ${{ steps.init_folders.outputs.model_prefix_folder }}
         - Sparse Prune Ratio: ${{ steps.parse_custom_params.outputs.sparse_prune_ratio || 'N/A' }}
         - Activation: ${{ steps.parse_custom_params.outputs.activation || 'N/A' }}
-        - Trust Remote Code: ${{ steps.parse_custom_params.outputs.trust_remote_code || 'N/A' }}
+        - Model Init Kwargs: ${{ steps.parse_custom_params.outputs.model_init_kwargs || '{}' }}
         
         ======== Workflow Output Information =========
         - Embedding Verification: Passed"
@@ -196,7 +196,7 @@ jobs:
       sparse_prune_ratio: ${{ steps.parse_custom_params.outputs.sparse_prune_ratio }}
       activation: ${{ steps.parse_custom_params.outputs.activation }}
       model_name: ${{ steps.parse_custom_params.outputs.model_name }}
-      trust_remote_code: ${{ steps.parse_custom_params.outputs.trust_remote_code }}
+      model_init_kwargs: ${{ steps.parse_custom_params.outputs.model_init_kwargs }}
 
   # Step 3: Check if the model already exists in the model hub
   checking-out-model-hub:
@@ -274,7 +274,7 @@ jobs:
           echo "MODEL_NAME=${{ needs.init-workflow-var.outputs.model_name }}" >> $GITHUB_ENV
           echo "SPARSE_PRUNE_RATIO=${{ needs.init-workflow-var.outputs.sparse_prune_ratio }}" >> $GITHUB_ENV
           echo "ACTIVATION=${{ needs.init-workflow-var.outputs.activation }}" >> $GITHUB_ENV
-          echo "TRUST_REMOTE_CODE=${{ needs.init-workflow-var.outputs.trust_remote_code }}" >> $GITHUB_ENV
+          echo "MODEL_INIT_KWARGS=${{ needs.init-workflow-var.outputs.model_init_kwargs }}" >> $GITHUB_ENV
       - name: Autotracing ${{ matrix.cluster }} secured=${{ matrix.secured }} version=${{matrix.entry.opensearch_version}}
         run: "./.ci/run-tests ${{ matrix.cluster }} ${{ matrix.secured }} ${{ matrix.entry.opensearch_version }} ${{github.event.inputs.model_type}}Trace"
         shell: bash

--- a/.github/workflows/model_uploader.yml
+++ b/.github/workflows/model_uploader.yml
@@ -67,6 +67,7 @@ on:
             "sparse_prune_ratio": (Optional) Float. Specifies the model-side prune ratio based on max values. Sparse model only.
             "activation": (Optional) String. Specifies the activation function for the sparse model. Sparse model only.
             "model_name": (Optional) String. Specifies the model name for uploading. Example: transforms "sentence-transformers/model" to "sentence-transformers/{model_name}",
+            "trust_remote_code": (Optional) Boolean. Specifies whether to trust remote model code.
           }
           
           Example:
@@ -102,23 +103,27 @@ jobs:
         sparse_prune_ratio=0
         activation=""
         model_name="${model_id##*/}"
+        trust_remote_code=false
 
         if [ "$custom_params" != "{}" ] && [ -n "$custom_params" ]; then
           tmp_up=$(echo "$custom_params" | jq -r '.upload_prefix | select(.!=null)')
           tmp_spr=$(echo "$custom_params" | jq -r '.sparse_prune_ratio | select(.!=null)')
           tmp_act=$(echo "$custom_params" | jq -r '.activation | select(.!=null)')
           tmp_mn=$(echo "$custom_params" | jq -r '.model_name | select(.!=null)')
+          tmp_trc=$(echo "$custom_params" | jq -r '.trust_remote_code | select(.!=null)')
 
           [ -n "$tmp_up" ] && upload_prefix="$tmp_up"
           [ -n "$tmp_spr" ] && sparse_prune_ratio="$tmp_spr"
           [ -n "$tmp_act" ] && activation="$tmp_act"
           [ -n "$tmp_mn" ] && model_name="$tmp_mn"
+          [ -n "$tmp_trc" ] && trust_remote_code="$tmp_trc"
         fi
 
         echo "upload_prefix=$upload_prefix" >> $GITHUB_OUTPUT
         echo "sparse_prune_ratio=$sparse_prune_ratio" >> $GITHUB_OUTPUT
         echo "activation=$activation" >> $GITHUB_OUTPUT
         echo "model_name=$model_name" >> $GITHUB_OUTPUT
+        echo "trust_remote_code=$trust_remote_code" >> $GITHUB_OUTPUT
     - name: Initiate folders
       # This scripts init the folders path variables.
       # 1. Retrieves the input model_id.
@@ -167,6 +172,7 @@ jobs:
         - Model Prefix Folder: ${{ steps.init_folders.outputs.model_prefix_folder }}
         - Sparse Prune Ratio: ${{ steps.parse_custom_params.outputs.sparse_prune_ratio || 'N/A' }}
         - Activation: ${{ steps.parse_custom_params.outputs.activation || 'N/A' }}
+        - Trust Remote Code: ${{ steps.parse_custom_params.outputs.trust_remote_code || 'N/A' }}
         
         ======== Workflow Output Information =========
         - Embedding Verification: Passed"
@@ -190,6 +196,7 @@ jobs:
       sparse_prune_ratio: ${{ steps.parse_custom_params.outputs.sparse_prune_ratio }}
       activation: ${{ steps.parse_custom_params.outputs.activation }}
       model_name: ${{ steps.parse_custom_params.outputs.model_name }}
+      trust_remote_code: ${{ steps.parse_custom_params.outputs.trust_remote_code }}
 
   # Step 3: Check if the model already exists in the model hub
   checking-out-model-hub:
@@ -267,6 +274,7 @@ jobs:
           echo "MODEL_NAME=${{ needs.init-workflow-var.outputs.model_name }}" >> $GITHUB_ENV
           echo "SPARSE_PRUNE_RATIO=${{ needs.init-workflow-var.outputs.sparse_prune_ratio }}" >> $GITHUB_ENV
           echo "ACTIVATION=${{ needs.init-workflow-var.outputs.activation }}" >> $GITHUB_ENV
+          echo "TRUST_REMOTE_CODE=${{ needs.init-workflow-var.outputs.trust_remote_code }}" >> $GITHUB_ENV
       - name: Autotracing ${{ matrix.cluster }} secured=${{ matrix.secured }} version=${{matrix.entry.opensearch_version}}
         run: "./.ci/run-tests ${{ matrix.cluster }} ${{ matrix.secured }} ${{ matrix.entry.opensearch_version }} ${{github.event.inputs.model_type}}Trace"
         shell: bash

--- a/opensearch_py_ml/ml_models/sparse_encoding_model.py
+++ b/opensearch_py_ml/ml_models/sparse_encoding_model.py
@@ -50,12 +50,13 @@ class SparseEncodingModel(SparseModel):
         overwrite: bool = False,
         sparse_prune_ratio: float = 0,
         activation: str = None,
+        trust_remote_code: bool = False,
     ) -> None:
 
         super().__init__(model_id, folder_path, overwrite)
         self.tokenizer = AutoTokenizer.from_pretrained(model_id)
         self.backbone_model = AutoModelForMaskedLM.from_pretrained(
-            model_id, _attn_implementation="eager"
+            model_id, _attn_implementation="eager", trust_remote_code=trust_remote_code
         )
         default_folder_path = os.path.join(
             os.getcwd(), "opensearch_neural_sparse_model_files"
@@ -78,7 +79,7 @@ class SparseEncodingModel(SparseModel):
         self.onnx_zip_file_path = None
         self.sparse_prune_ratio = sparse_prune_ratio
         self.activation = activation
-
+        
     def save_as_pt(
         self,
         sentences: [str],

--- a/opensearch_py_ml/ml_models/sparse_encoding_model.py
+++ b/opensearch_py_ml/ml_models/sparse_encoding_model.py
@@ -7,6 +7,7 @@
 import json
 import os
 from zipfile import ZipFile
+from typing import Optional
 
 import torch
 from transformers import AutoModelForMaskedLM, AutoTokenizer
@@ -50,13 +51,15 @@ class SparseEncodingModel(SparseModel):
         overwrite: bool = False,
         sparse_prune_ratio: float = 0,
         activation: str = None,
-        trust_remote_code: bool = False,
+        model_init_kwargs: Optional[dict] = None,
     ) -> None:
 
         super().__init__(model_id, folder_path, overwrite)
-        self.tokenizer = AutoTokenizer.from_pretrained(model_id)
+        if model_init_kwargs is None:
+            model_init_kwargs = {}
+        self.tokenizer = AutoTokenizer.from_pretrained(model_id, **model_init_kwargs)
         self.backbone_model = AutoModelForMaskedLM.from_pretrained(
-            model_id, _attn_implementation="eager", trust_remote_code=trust_remote_code
+            model_id, _attn_implementation="eager", **model_init_kwargs
         )
         default_folder_path = os.path.join(
             os.getcwd(), "opensearch_neural_sparse_model_files"

--- a/utils/model_uploader/autotracing_utils.py
+++ b/utils/model_uploader/autotracing_utils.py
@@ -8,7 +8,7 @@ import json
 import os
 import shutil
 import warnings
-from typing import Type, TypeVar
+from typing import Any, Dict, Optional, Type, TypeVar
 
 from huggingface_hub import HfApi
 
@@ -230,16 +230,23 @@ T = TypeVar("T")
 
 
 def init_sparse_model(
-    model_class: Type[T], model_id, folder_path, sparse_prune_ratio=0, activation=None, trust_remote_code=False
+    model_class: Type[T],
+    model_id,
+    folder_path,
+    sparse_prune_ratio=0,
+    activation=None,
+    model_init_kwargs: Optional[Dict[str, Any]] = None,
 ) -> T:
     try:
+        if model_init_kwargs is None:
+            model_init_kwargs = {}
         pre_trained_model = model_class(
             model_id=model_id,
             folder_path=folder_path,
             overwrite=True,
             sparse_prune_ratio=sparse_prune_ratio,
             activation=activation,
-            trust_remote_code=trust_remote_code,
+            model_init_kwargs=model_init_kwargs,
         )
     except Exception as e:
         raise ModelTraceError("initiating a sparse encoding model class object", e)

--- a/utils/model_uploader/autotracing_utils.py
+++ b/utils/model_uploader/autotracing_utils.py
@@ -230,7 +230,7 @@ T = TypeVar("T")
 
 
 def init_sparse_model(
-    model_class: Type[T], model_id, folder_path, sparse_prune_ratio=0, activation=None
+    model_class: Type[T], model_id, folder_path, sparse_prune_ratio=0, activation=None, trust_remote_code=False
 ) -> T:
     try:
         pre_trained_model = model_class(
@@ -239,6 +239,7 @@ def init_sparse_model(
             overwrite=True,
             sparse_prune_ratio=sparse_prune_ratio,
             activation=activation,
+            trust_remote_code=trust_remote_code,
         )
     except Exception as e:
         raise ModelTraceError("initiating a sparse encoding model class object", e)

--- a/utils/model_uploader/sparse_model_autotracing.py
+++ b/utils/model_uploader/sparse_model_autotracing.py
@@ -92,7 +92,12 @@ def trace_sparse_encoding_model(
     # 1.) Initiate a sparse encoding model class object
     model_cls = SparseTokenizeModel if is_tokenizer else SparseEncodingModel
     pre_trained_model = init_sparse_model(
-        model_cls, model_id, folder_path, sparse_prune_ratio, activation, model_init_kwargs
+        model_cls,
+        model_id,
+        folder_path,
+        sparse_prune_ratio,
+        activation,
+        model_init_kwargs,
     )
 
     # 2.) Save the model in the specified format


### PR DESCRIPTION
### Description
1. Add model_init_kwargs to sparse model uploading pipeline call stack. So that we can pass params like `trust_remote_code`, `code_revision`.
2. Add module sanitize logics so that the traced model can be load correctly.
 
### Issues Resolved
#554 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
