### PR TITLE
Update space type value from `cosine` to `cosinesimil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update pretrained_models_all_versions.json by @nathaliellenaa ([#560](https://github.com/opensearch-project/opensearch-py-ml/pull/560))
 - Upgrade torch version to fix security issue ([#561](https://github.com/opensearch-project/opensearch-py-ml/pull/561))
 - Upgrade numpy and python version ([#562](https://github.com/opensearch-project/opensearch-py-ml/pull/562))
+- Update space type mapping for sentence transformer models ([#574](https://github.com/opensearch-project/opensearch-py-ml/pull/574))
 
 ### Fixed
 - Fix for uploading models with function_name instead of model_task ([#553](https://github.com/opensearch-project/opensearch-py-ml/pull/553))

--- a/opensearch_py_ml/ml_models/sentencetransformermodel.py
+++ b/opensearch_py_ml/ml_models/sentencetransformermodel.py
@@ -61,10 +61,10 @@ class SentenceTransformerModel(BaseUploadModel):
         "msmarco-distilbert-base-tas-b": "innerproduct",
         "multi-qa-MiniLM-L6-cos-v1": "l2",
         "multi-qa-mpnet-base-dot-v1": "innerproduct",
-        "paraphrase-MiniLM-L3-v2": "cosine",
-        "paraphrase-multilingual-MiniLM-L12-v2": "cosine",
-        "paraphrase-mpnet-base-v2": "cosine",
-        "distiluse-base-multilingual-cased-v1": "cosine",
+        "paraphrase-MiniLM-L3-v2": "cosinesimil",
+        "paraphrase-multilingual-MiniLM-L12-v2": "cosinesimil",
+        "paraphrase-mpnet-base-v2": "cosinesimil",
+        "distiluse-base-multilingual-cased-v1": "cosinesimil",
     }
 
     def __init__(

--- a/tests/ml_models/test_sentencetransformermodel_pytest.py
+++ b/tests/ml_models/test_sentencetransformermodel_pytest.py
@@ -276,7 +276,7 @@ def test_make_model_config_json_for_onnx():
         "embedding_dimension": 384,
         "pooling_mode": "MEAN",
         "normalize_result": False,
-        "additional_config": {"space_type": "cosine"},
+        "additional_config": {"space_type": "cosinesimil"},
     }
 
     clean_test_folder(TEST_FOLDER)
@@ -313,7 +313,7 @@ def test_overwrite_fields_in_model_config():
         "embedding_dimension": 128,
         "pooling_mode": "MAX",
         "normalize_result": False,
-        "additional_config": {"space_type": "cosine"},
+        "additional_config": {"space_type": "cosinesimil"},
     }
 
     clean_test_folder(TEST_FOLDER)


### PR DESCRIPTION
### Description
Update space type value from `cosine` to `cosinesimil`
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/4166
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
