### PR TITLE
Adds interactive and output path options to model register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Add agentic memory integration script ([#593](https://github.com/opensearch-project/opensearch-py-ml/pull/593))
+- Standardized interactive mode `-i/--interactive` for <u>model registration</u> CLI command to adhere to common conventions. ([#591](https://github.com/opensearch-project/opensearch-py-ml/pull/591))
+- Add `-o/--output` option to <u>model registration</u> to specify output file path enabling end to end automation. ([#591](https://github.com/opensearch-project/opensearch-py-ml/pull/591))
+- Update documentation for <u>model registration</u> to reflect new options and usage. ([#591](https://github.com/opensearch-project/opensearch-py-ml/pull/591))
 
 ### Changed
 - Update semantic highlighting sagemaker endpoint deploy scripts ([#585](https://github.com/opensearch-project/opensearch-py-ml/pull/585))

--- a/docs/source/cli/register_model.rst
+++ b/docs/source/cli/register_model.rst
@@ -56,7 +56,7 @@ Usage examples
 
     ``opensearch-ml model register --connectorId 'connector123' --name 'Test model' --description 'This is a test model' -o /Documents/cli/output.yml``
 
-    If `-o` or `--output` is not specified, the output file will be saved in the current directory in non-interactive mode.
+    If `-o` or `--outputPath` is not specified, the output file will be saved in the current directory in non-interactive mode.
 
     Sample response:
 

--- a/docs/source/cli/register_model.rst
+++ b/docs/source/cli/register_model.rst
@@ -12,13 +12,16 @@ Use the `model register` command to register an externally hosted model with Ope
 Command syntax
 ~~~~~~~~~~~~~~
 
-``opensearch-ml model register [--connectorId '<value>'][--name '<value>'][--description '<value>']``
+``opensearch-ml model register [-h][-i][--connectorId '<value>'][--name '<value>'][--description '<value>'][-o <value>]``
 
 **Options:**
 
+* ``-h``: Show help message and exit
+* ``-i``: (Optional) Enable interactive mode for model registration. Off by default
 * ``--connectorId '<value>'``: (Optional) The connector ID to associate the model with
 * ``--name '<value>'``: (Optional) The name of the model
 * ``--description '<value>'``: (Optional) A brief description of the model
+* ``-o <value>``: (Optional) The file path to save the output information. If not provided, the output will be saved in the current directory while in non-interactive mode
 
 Usage examples
 ~~~~~~~~~~~~~~
@@ -27,7 +30,7 @@ Usage examples
 
     Use the following command to register a model interactively:
 
-    ``opensearch-ml model register``
+    ``opensearch-ml model register -i``
 
     Sample response:
 
@@ -51,7 +54,9 @@ Usage examples
 
     To register a model directly, provide all parameters to the following command:
 
-    ``opensearch-ml model register --connectorId 'connector123' --name 'Test model' --description 'This is a test model'``
+    ``opensearch-ml model register --connectorId 'connector123' --name 'Test model' --description 'This is a test model' -o /Documents/cli/output.yml``
+
+    If `-o` or `--output` is not specified, the output file will be saved in the current directory in non-interactive mode.
 
     Sample response:
 
@@ -62,8 +67,6 @@ Usage examples
         Setup configuration loaded successfully from /Documents/cli/setup_config.yml
 
         Successfully registered a model with ID: model123
-
-        Enter the path to save the output information, or press Enter to save it in the current directory [/Documents/cli/output.yml]: 
 
         Output information saved successfully to /Documents/cli/output.yml
 

--- a/opensearch_py_ml/ml_commons/cli/cli_base.py
+++ b/opensearch_py_ml/ml_commons/cli/cli_base.py
@@ -362,7 +362,13 @@ class CLIBase:
                 "response": response,
             }
         )
-        self.save_yaml_file(self.output_config, "output", merge_existing=True)
+        self.save_yaml_file(
+            self.output_config,
+            "output",
+            merge_existing=True,
+            output_path=None,
+            interactive=True,
+        )
 
     def get_opensearch_domain_name(
         self, opensearch_domain_endpoint: str

--- a/opensearch_py_ml/ml_commons/cli/cli_base.py
+++ b/opensearch_py_ml/ml_commons/cli/cli_base.py
@@ -129,6 +129,9 @@ class CLIBase:
             merge_existing (optional): Whether to merge with existing file content
                 if the file exists. Defaults to False. If False and file exists, will
                 prompt for overwrite confirmation.
+            output_path (optional): Path to save the output information.
+                It overrides the default or configured path, since it is explicitely provided by the user.
+            interactive (optional): Whether to run in interactive mode, False by default.
 
         Returns:
             Optional[str]: The absolute path where the file was saved, or None if:
@@ -330,6 +333,9 @@ class CLIBase:
             model_id: The registered model ID.
             model_name: The registered model name.
             connector_id: The connector ID associated with the registered model.
+            output_path (optional): Path to save the output information.
+                                    If not provided, output will be current working directory.
+            interactive (optional): Whether to run in interactive mode.
         """
         # Update the register_model section
         self.output_config["register_model"].append(

--- a/opensearch_py_ml/ml_commons/cli/cli_base.py
+++ b/opensearch_py_ml/ml_commons/cli/cli_base.py
@@ -280,6 +280,8 @@ class CLIBase:
         role_arn: Optional[str] = None,
         secret_name: Optional[str] = None,
         secret_arn: Optional[str] = None,
+        interactive: bool = True,
+        output_path: Optional[str] = None,
     ) -> None:
         """
         Save connector output to a YAML file.
@@ -305,7 +307,13 @@ class CLIBase:
                 "connector_secret_name": secret_name or "",
             }
         )
-        self.save_yaml_file(self.output_config, "output", merge_existing=True)
+        self.save_yaml_file(
+            self.output_config,
+            "output",
+            merge_existing=True,
+            output_path=output_path,
+            interactive=interactive,
+        )
 
     def register_model_output(
         self,

--- a/opensearch_py_ml/ml_commons/cli/ml_cli.py
+++ b/opensearch_py_ml/ml_commons/cli/ml_cli.py
@@ -113,6 +113,9 @@ Examples:
   Register a model with a model name, description, and the connector ID
     opensearch-ml model register --connectorId 'connector123' --name 'Test model' --description 'This is a test model'
     
+  Register a model with a model name, description, and the connector ID, optionally provide output path:
+    opensearch-ml model register --connectorId 'connector123' --name 'Test model' --description 'This is a test model' --outputPath '/file/output.json'
+    
   Register a model in interactive mode:
     opensearch-ml model register -i
 

--- a/opensearch_py_ml/ml_commons/cli/ml_cli.py
+++ b/opensearch_py_ml/ml_commons/cli/ml_cli.py
@@ -112,6 +112,9 @@ Examples:
 
   Register a model with a model name, description, and the connector ID
     opensearch-ml model register --connectorId 'connector123' --name 'Test model' --description 'This is a test model'
+    
+  Register a model in interactive mode:
+    opensearch-ml model register -i
 
   Predict a model:
     opensearch-ml model predict
@@ -162,6 +165,12 @@ Examples:
         "register", help="Register a new model"
     )
     model_register.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help="Register a model in interactive mode",
+    )
+    model_register.add_argument(
         "--connectorId",
         action=AllowDashActionConnector,
         help="The connector ID to register the model with.",
@@ -177,6 +186,12 @@ Examples:
         "--description",
         help="Description of the model to register.",
         metavar="MODEL_DESCRIPTION",
+    )
+    model_register.add_argument(
+        "-o",
+        "--outputPath",
+        help="Path to save the output information.",
+        metavar="OUTPUT_PATH",
     )
 
     # Predict command
@@ -255,11 +270,15 @@ Examples:
             connector_id = getattr(args, "connectorId", None)
             model_name = args.name if args.name else None
             model_description = args.description if args.description else None
+            output_path = args.outputPath if args.outputPath else None
+            is_interactive_mode = args.interactive if args.interactive else False
             model_manager.initialize_register_model(
                 config_path,
                 connector_id=connector_id,
                 model_name=model_name,
                 model_description=model_description,
+                output_path=output_path,
+                interactive=is_interactive_mode,
             )
         elif args.subcommand == "predict":
             # Read the saved setup config path

--- a/opensearch_py_ml/ml_commons/cli/ml_cli.py
+++ b/opensearch_py_ml/ml_commons/cli/ml_cli.py
@@ -112,10 +112,10 @@ Examples:
 
   Register a model with a model name, description, and the connector ID
     opensearch-ml model register --connectorId 'connector123' --name 'Test model' --description 'This is a test model'
-    
+
   Register a model with a model name, description, and the connector ID, optionally provide output path:
     opensearch-ml model register --connectorId 'connector123' --name 'Test model' --description 'This is a test model' --outputPath '/file/output.json'
-    
+
   Register a model in interactive mode:
     opensearch-ml model register -i
 

--- a/opensearch_py_ml/ml_commons/cli/model_manager.py
+++ b/opensearch_py_ml/ml_commons/cli/model_manager.py
@@ -114,6 +114,8 @@ class ModelManager(CLIBase):
             connector_id (optional): The connector ID to register the model with.
             model_name (optional): Name of the model.
             model_description (optional): Description of the model.
+            output_path (optional): Path to save the output information.
+            interactive (optional): Whether to run in interactive mode.
 
         Returns:
             bool: True if registration successful, False otherwise

--- a/opensearch_py_ml/ml_commons/cli/model_manager.py
+++ b/opensearch_py_ml/ml_commons/cli/model_manager.py
@@ -103,6 +103,8 @@ class ModelManager(CLIBase):
         connector_id: Optional[str] = None,
         model_name: Optional[str] = None,
         model_description: Optional[str] = None,
+        output_path: Optional[str] = None,
+        interactive: bool = False,
     ) -> bool:
         """
         Orchestrates the entire model registration process.
@@ -123,6 +125,27 @@ class ModelManager(CLIBase):
                 return False
             ai_helper, _, _, _ = config_result
 
+            # In non-interactive mode, ensure all required parameters are provided
+            if not interactive:
+                # Specify which parameters are missing
+                missing_params = []
+                if not model_name:
+                    missing_params.append("--name")
+                if not model_description:
+                    missing_params.append("--description")
+                if not connector_id:
+                    missing_params.append("--connectorId")
+
+                if missing_params:
+                    missing_str = "\n\t".join(missing_params)
+                    logger.error(
+                        "%sMissing required parameters: \n\t%s%s",
+                        Fore.RED,
+                        missing_str,
+                        Style.RESET_ALL,
+                    )
+                    return False  # Early return due to missing parameters
+
             # Prompt for model name, description, and connector ID if not provided
             if not model_name:
                 model_name = input("\nEnter the model name: ").strip()
@@ -137,12 +160,14 @@ class ModelManager(CLIBase):
 
             if model_id:
                 print(
-                    f"{Fore.GREEN}\nSuccessfully registered a model with ID: {model_id}{Style.RESET_ALL}"
+                    f"{Fore.GREEN}\nSuccessfully registered a model with IDs: {model_id}{Style.RESET_ALL}"
                 )
-                self.register_model_output(model_id, model_name, connector_id)
+                self.register_model_output(
+                    model_id, model_name, connector_id, output_path, interactive
+                )
                 return True
-            else:
-                logger.warning(f"{Fore.RED}Failed to register model.{Style.RESET_ALL}")
-                return False
+
+            logger.warning(f"{Fore.RED}Failed to register model.{Style.RESET_ALL}")
+            return False
         except Exception:
             return False

--- a/tests/cli/test_cli_base.py
+++ b/tests/cli/test_cli_base.py
@@ -517,7 +517,7 @@ class TestCLIBase(unittest.TestCase):
         # Verify
         self.assertEqual(self.cli_base.output_config["predict_model"], expected_update)
         self.cli_base.save_yaml_file.assert_called_once_with(
-            self.cli_base.output_config, "output", merge_existing=True
+            self.cli_base.output_config, "output", merge_existing=True, output_path=None, interactive=True
         )
 
     def test_get_opensearch_domain_name(self):

--- a/tests/cli/test_cli_base.py
+++ b/tests/cli/test_cli_base.py
@@ -230,7 +230,10 @@ class TestCLIBase(unittest.TestCase):
 
         # Execute
         save_result = self.cli_base.save_yaml_file(
-            config=test_config, file_type="output", merge_existing=True, interactive=True
+            config=test_config,
+            file_type="output",
+            merge_existing=True,
+            interactive=True,
         )
 
         # Verify result
@@ -462,7 +465,11 @@ class TestCLIBase(unittest.TestCase):
             self.cli_base.output_config["connector_create"], expected_update
         )
         self.cli_base.save_yaml_file.assert_called_once_with(
-            self.cli_base.output_config, "output", merge_existing=True, output_path=None, interactive=True
+            self.cli_base.output_config,
+            "output",
+            merge_existing=True,
+            output_path=None,
+            interactive=True,
         )
 
     @patch.object(CLIBase, "save_yaml_file", Mock())
@@ -495,13 +502,20 @@ class TestCLIBase(unittest.TestCase):
 
         # Execute
         self.cli_base.register_model_output(
-            model_id=model_id, model_name=model_name, connector_id=connector_id, interactive=True
+            model_id=model_id,
+            model_name=model_name,
+            connector_id=connector_id,
+            interactive=True,
         )
 
         # Verify
         self.assertEqual(self.cli_base.output_config["register_model"], expected_update)
         self.cli_base.save_yaml_file.assert_called_once_with(
-            self.cli_base.output_config, "output", merge_existing=True, output_path=None, interactive=True
+            self.cli_base.output_config,
+            "output",
+            merge_existing=True,
+            output_path=None,
+            interactive=True,
         )
 
     @patch.object(CLIBase, "save_yaml_file", Mock())
@@ -517,7 +531,11 @@ class TestCLIBase(unittest.TestCase):
         # Verify
         self.assertEqual(self.cli_base.output_config["predict_model"], expected_update)
         self.cli_base.save_yaml_file.assert_called_once_with(
-            self.cli_base.output_config, "output", merge_existing=True, output_path=None, interactive=True
+            self.cli_base.output_config,
+            "output",
+            merge_existing=True,
+            output_path=None,
+            interactive=True,
         )
 
     def test_get_opensearch_domain_name(self):

--- a/tests/cli/test_cli_base.py
+++ b/tests/cli/test_cli_base.py
@@ -462,7 +462,7 @@ class TestCLIBase(unittest.TestCase):
             self.cli_base.output_config["connector_create"], expected_update
         )
         self.cli_base.save_yaml_file.assert_called_once_with(
-            self.cli_base.output_config, "output", merge_existing=True
+            self.cli_base.output_config, "output", merge_existing=True, output_path=None, interactive=True
         )
 
     @patch.object(CLIBase, "save_yaml_file", Mock())

--- a/tests/cli/test_cli_base.py
+++ b/tests/cli/test_cli_base.py
@@ -230,7 +230,7 @@ class TestCLIBase(unittest.TestCase):
 
         # Execute
         save_result = self.cli_base.save_yaml_file(
-            config=test_config, file_type="output", merge_existing=True
+            config=test_config, file_type="output", merge_existing=True, interactive=True
         )
 
         # Verify result
@@ -267,7 +267,7 @@ class TestCLIBase(unittest.TestCase):
     def test_save_yaml_file_keyboard_interrupt(self, mock_input, mock_logger):
         """Test save_yaml_file keyboard interrupt handling"""
         mock_input.side_effect = KeyboardInterrupt()
-        result = self.cli_base.save_yaml_file(self.test_config)
+        result = self.cli_base.save_yaml_file(self.test_config, interactive=True)
         self.assertIsNone(result)
         mock_logger.error.assert_called_once_with(
             f"\n{Fore.YELLOW}Operation cancelled by user.{Style.RESET_ALL}"
@@ -495,13 +495,13 @@ class TestCLIBase(unittest.TestCase):
 
         # Execute
         self.cli_base.register_model_output(
-            model_id=model_id, model_name=model_name, connector_id=connector_id
+            model_id=model_id, model_name=model_name, connector_id=connector_id, interactive=True
         )
 
         # Verify
         self.assertEqual(self.cli_base.output_config["register_model"], expected_update)
         self.cli_base.save_yaml_file.assert_called_once_with(
-            self.cli_base.output_config, "output", merge_existing=True
+            self.cli_base.output_config, "output", merge_existing=True, output_path=None, interactive=True
         )
 
     @patch.object(CLIBase, "save_yaml_file", Mock())

--- a/tests/cli/test_ml_cli.py
+++ b/tests/cli/test_ml_cli.py
@@ -142,6 +142,7 @@ class TestMLCLI(unittest.TestCase):
             "test model",
             "--description",
             "test description",
+            "-i",
         ]
         with patch.object(sys, "argv", test_args):
             main()
@@ -150,6 +151,8 @@ class TestMLCLI(unittest.TestCase):
                 connector_id="connector123",
                 model_name="test model",
                 model_description="test description",
+                output_path=None,
+                interactive=True,
             )
 
     @patch("opensearch_py_ml.ml_commons.cli.ml_cli.logger")
@@ -280,6 +283,7 @@ class TestMLCLI(unittest.TestCase):
             "test model",
             "--description",
             "test description",
+            "-i",
         ]
         with patch.object(sys, "argv", test_args):
             main()
@@ -288,6 +292,8 @@ class TestMLCLI(unittest.TestCase):
                 connector_id="-connector123",
                 model_name="test model",
                 model_description="test description",
+                output_path=None,
+                interactive=True,
             )
 
     @patch("argparse.ArgumentParser.error")

--- a/tests/cli/test_model_manager.py
+++ b/tests/cli/test_model_manager.py
@@ -248,7 +248,7 @@ class TestModelManager(unittest.TestCase):
         mock_load_check_config.return_value = (mock_ai_helper, None, None, None)
 
         # Execute
-        result = self.model_manager.initialize_register_model(self.config_path)
+        result = self.model_manager.initialize_register_model(self.config_path, interactive=True)
 
         # Verify result
         self.assertTrue(result)

--- a/tests/cli/test_model_manager.py
+++ b/tests/cli/test_model_manager.py
@@ -248,7 +248,9 @@ class TestModelManager(unittest.TestCase):
         mock_load_check_config.return_value = (mock_ai_helper, None, None, None)
 
         # Execute
-        result = self.model_manager.initialize_register_model(self.config_path, interactive=True)
+        result = self.model_manager.initialize_register_model(
+            self.config_path, interactive=True
+        )
 
         # Verify result
         self.assertTrue(result)


### PR DESCRIPTION
### Description
Enables interactive mode and custom output path selection when registering a model via the CLI. Improves user experience by allowing prompts for missing parameters and adds validation for required arguments in non-interactive mode. Updates tests to cover new options.

Interactive mode, will prompt you for missing options
```bash
opensearch-ml model register -i
```

If no `-i` or `--interactive` flag is provided, by default non-interactive mode will be run
```bash
opensearch-ml model register \
--connectorId "$CONNECTOR_ID" \
--name "Example embedding" \
--description "Example embedding model connector" \
--outputPath "/path/to/file" # new option for improved automation
```

In non-interactive mode, each specific missing parameter will be listed and the application will be stopped until all requirements are met.
```
opensearch-ml model register

Starting model registration...

Setup configuration loaded successfully from /home/rikkarth/repoland/opensearch-py-ml/test_config.yml
Missing required parameters: 
        --name
        --description
        --connectorId
```

### Issues Resolved
- https://github.com/opensearch-project/opensearch-py-ml/issues/590
 
### Follow ups
Both predict and connector registration still do not support non-interactive modes. I will address this in two seperate PRs so it can be more digestable. In the meantime both predict and connector logic have been made backwards compatible with their existing implementation.

### Check List
- [x] New functionality includes testing.
  - [x] Existing tests have been reviewed and aligned with the new functionality.
  - [ ] All tests pass (could not run pipeline on github, locally all cli package tests pass)
- [x] New functionality has been documented.
  - [x] New functionality has docstrings added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
