### PR TITLE
Fix mcorr model auto tracing workflow

### DIFF
--- a/utils/model_uploader/metrics_correlation_autotracing.py
+++ b/utils/model_uploader/metrics_correlation_autotracing.py
@@ -143,10 +143,7 @@ def main(
     # Preview and prepare files for uploading
     preview_model_config(tracing_format, config_file_path)
 
-    # Store description
-    store_description_variable(model_description)
-
-    prepare_files_for_uploading(
+    mcorr_model_path, mcorr_model_config_path = prepare_files_for_uploading(
         model_id=model_id,
         model_version=model_version,
         model_format=tracing_format,
@@ -155,6 +152,9 @@ def main(
         upload_prefix=None,
         model_name=model_name,
     )
+
+    # Store description
+    store_description_variable(mcorr_model_config_path)
 
     print("=== Metrics correlation auto-tracing completed ===")
 


### PR DESCRIPTION
### Description
Fix mcorr model auto tracing workflow
 
### Issues Resolved
Sample failed workflow: https://github.com/opensearch-project/opensearch-py-ml/actions/runs/20604437913/job/59177109318
Failed due to:
```
Traceback (most recent call last):
  File "/code/opensearch-py-ml/utils/model_uploader/../../utils/model_uploader/autotracing_utils.py", line 174, in store_description_variable
    with open(config_path_for_checking_description, "r") as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'A metrics correlation model that detects anomalous events in time series data by identifying when multiple metrics simultaneously display unusual behavior.'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/code/opensearch-py-ml/utils/model_uploader/metrics_correlation_autotracing.py", line 215, in <module>
    main(
  File "/code/opensearch-py-ml/utils/model_uploader/metrics_correlation_autotracing.py", line 147, in main
    store_description_variable(model_description)
  File "/code/opensearch-py-ml/utils/model_uploader/../../utils/model_uploader/autotracing_utils.py", line 185, in store_description_variable
    f"Cannot store description ({description}) in {description_var_filepath}: {e}"
                                 ^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'description' where it is not associated with a value
```
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
