### PR TITLE
set fixed transformer verison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update documentation for <u>model registration</u> to reflect new options and usage. ([#591](https://github.com/opensearch-project/opensearch-py-ml/pull/591))
 
 ### Changed
+- Set upperbound for transformers in semantic highlighter requirements to fix compatibility issue ([#599](https://github.com/opensearch-project/opensearch-py-ml/pull/599))
 - Update semantic highlighting sagemaker endpoint deploy scripts ([#585](https://github.com/opensearch-project/opensearch-py-ml/pull/585))
 - Update doc workflow to use 2.19.0 ([#598](https://github.com/opensearch-project/opensearch-py-ml/pull/598))
 - Update asymmetric embedding sagemaker endpoint deploy scripts ([#601](https://github.com/opensearch-project/opensearch-py-ml/pull/601))

--- a/docs/source/examples/semantic_highlighting/opensearch-semantic-highlighter/requirements.txt
+++ b/docs/source/examples/semantic_highlighting/opensearch-semantic-highlighter/requirements.txt
@@ -1,5 +1,5 @@
 torch>=2.6.0
-transformers>=4.48.0
+transformers==4.48.0
 nltk>=3.8
 numpy>=1.24.0
 safetensors>=0.3.1

--- a/docs/source/examples/semantic_highlighting/opensearch-semantic-highlighter/requirements.txt
+++ b/docs/source/examples/semantic_highlighting/opensearch-semantic-highlighter/requirements.txt
@@ -1,5 +1,5 @@
 torch>=2.6.0
-transformers>=4.48.0
+transformers>=4.48.0,5
 nltk>=3.8
 numpy>=1.24.0
 safetensors>=0.3.1


### PR DESCRIPTION
### Description
Problem: the existing semantic highlighting sagemaker endpoint used in ML playground: https://ml.playground.opensearch.org was broken, and was replaced with `modernbert`. This PR revises the `requirement.txt` file to a working transformer version for `opensearch-semantic-highlighter-v1`

### Fix
set upper bound for transformer package to 5

### Testing

1. deployed a new sagemaker endpoint with changes made in `requirement.txt` file.

2. verified successful response 

```
pip install -r requirements.txt   

python3 deploy.py --model opensearch-semantic-highlighter 

aws sagemaker-runtime invoke-endpoint \                 
  --endpoint-name opensearch-semantic-highlighter-20260324-145844-3f04719a \
  --region us-east-1 \
  --content-type application/json \
  --body fileb:///tmp/payload.json \
  /dev/stdout
{"highlights": [{"start": 0, "end": 66}], "processing_time_ms": 239.83001708984375, "device": "cuda"}
    "ContentType": "application/json",
    "InvokedProductionVariant": "AllTraffic"
}
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
