### PR TITLE
Add GitHub environment to release workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,4 @@
-name: Release drafter
+name: Release Workflow
 
 # Push events to every tag not containing "/"
 on:
@@ -7,42 +7,33 @@ on:
       - "*"
 
 jobs:
-  draft-a-release:
+  release-to-pypi:
+    environment: release-approval
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write
-      issues: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
-      - id: get_approvers
-        run: |
-          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
-      - uses: trstringer/manual-approval@v1
-        with:
-          secret: ${{ github.TOKEN }}
-          approvers: ${{ steps.get_approvers.outputs.approvers }}
-          minimum-approvals: 2
-          issue-title: 'Release opensearch-py-ml'
-          issue-body: "Please approve or deny the release of opensearch-py-ml. **Tag**: ${{ github.ref_name }}  **Commit**: ${{ github.sha }}"
-          exclude-workflow-initiator-as-approver: true
+        uses: actions/checkout@v6
+
       - name: Set up Python 3
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
+
       - name: Install build tools
         run: |
           python -m pip install --upgrade build
+
       - name: Build project for distribution
         run: |
           python -m build
-          tar -zvcf artifacts.tar.gz dist
+
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-      - name: Draft a release
-        uses: softprops/action-gh-release@v1
+
+      - name: Release on Github
+        uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: |
-            artifacts.tar.gz


### PR DESCRIPTION
### Description
Add GitHub environment to release workflow
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
